### PR TITLE
Add serial connection creation operator

### DIFF
--- a/Bonsai.PulsePal/Bonsai.PulsePal.csproj
+++ b/Bonsai.PulsePal/Bonsai.PulsePal.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Bonsai.System" Version="2.6.0" />
+    <PackageReference Include="Bonsai.System" Version="2.8.1" />
     <PackageReference Include="OpenCV.Net" Version="3.4.2" />
   </ItemGroup>
 

--- a/Bonsai.PulsePal/ChannelParameter.cs
+++ b/Bonsai.PulsePal/ChannelParameter.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.ComponentModel;
 
 namespace Bonsai.PulsePal
 {

--- a/Bonsai.PulsePal/ChannelParameterCollection.cs
+++ b/Bonsai.PulsePal/ChannelParameterCollection.cs
@@ -1,11 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Collections.ObjectModel;
+﻿using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Drawing.Design;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Bonsai.PulsePal
 {

--- a/Bonsai.PulsePal/CreatePulsePal.cs
+++ b/Bonsai.PulsePal/CreatePulsePal.cs
@@ -6,11 +6,12 @@ using Bonsai.IO.Ports;
 
 namespace Bonsai.PulsePal
 {
+    [Description("Creates and configures a serial connection to a Pulse Pal device.")]
     public class CreatePulsePal : Source<PulsePal>, INamedElement
     {
         readonly PulsePalConfiguration configuration = new PulsePalConfiguration();
 
-        [Description("The optional alias for the Pulse Pal.")]
+        [Description("The optional alias for the Pulse Pal device.")]
         public string Name { get; set; }
 
         [TypeConverter(typeof(SerialPortNameConverter))]

--- a/Bonsai.PulsePal/CreatePulsePal.cs
+++ b/Bonsai.PulsePal/CreatePulsePal.cs
@@ -1,10 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using System.Reactive.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Bonsai.IO.Ports;
 
 namespace Bonsai.PulsePal

--- a/Bonsai.PulsePal/CreatePulsePal.cs
+++ b/Bonsai.PulsePal/CreatePulsePal.cs
@@ -5,7 +5,7 @@ using System.Linq;
 using System.Reactive.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using Bonsai.IO;
+using Bonsai.IO.Ports;
 
 namespace Bonsai.PulsePal
 {

--- a/Bonsai.PulsePal/CreatePulsePal.cs
+++ b/Bonsai.PulsePal/CreatePulsePal.cs
@@ -24,6 +24,13 @@ namespace Bonsai.PulsePal
             set { configuration.PortName = value; }
         }
 
+        /// <summary>
+        /// Generates an observable sequence that contains the serial connection object.
+        /// </summary>
+        /// <returns>
+        /// A sequence containing a single instance of the <see cref="PulsePal"/> class
+        /// representing the serial connection.
+        /// </returns>
         public override IObservable<PulsePal> Generate()
         {
             return Observable.Using(

--- a/Bonsai.PulsePal/CreatePulsePal.cs
+++ b/Bonsai.PulsePal/CreatePulsePal.cs
@@ -24,6 +24,12 @@ namespace Bonsai.PulsePal
             set { configuration.PortName = value; }
         }
 
+        [Description("The collection of channel parameters used to configure the Pulse Pal.")]
+        public ChannelParameterCollection ChannelParameters
+        {
+            get { return configuration.ChannelParameters; }
+        }
+
         /// <summary>
         /// Generates an observable sequence that contains the serial connection object.
         /// </summary>

--- a/Bonsai.PulsePal/CreatePulsePal.cs
+++ b/Bonsai.PulsePal/CreatePulsePal.cs
@@ -34,7 +34,7 @@ namespace Bonsai.PulsePal
         public override IObservable<PulsePal> Generate()
         {
             return Observable.Using(
-                () => PulsePalManager.ReserveConnection(configuration.PortName),
+                () => PulsePalManager.ReserveConnection(Name, configuration),
                 resource =>
                 {
                     return Observable.Return(resource.PulsePal)

--- a/Bonsai.PulsePal/CreatePulsePal.cs
+++ b/Bonsai.PulsePal/CreatePulsePal.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Bonsai.IO;
+
+namespace Bonsai.PulsePal
+{
+    public class CreatePulsePal : Source<PulsePal>, INamedElement
+    {
+        readonly PulsePalConfiguration configuration = new PulsePalConfiguration();
+
+        [Description("The optional alias for the Pulse Pal.")]
+        public string Name { get; set; }
+
+        [TypeConverter(typeof(SerialPortNameConverter))]
+        [Description("The name of the serial port used to communicate with the Pulse Pal.")]
+        public string PortName
+        {
+            get { return configuration.PortName; }
+            set { configuration.PortName = value; }
+        }
+
+        public override IObservable<PulsePal> Generate()
+        {
+            return Observable.Using(
+                () => PulsePalManager.ReserveConnection(configuration.PortName),
+                resource =>
+                {
+                    return Observable.Return(resource.PulsePal)
+                                     .Concat(Observable.Never(resource.PulsePal));
+                }
+            );
+        }
+    }
+}

--- a/Bonsai.PulsePal/ParameterCode.cs
+++ b/Bonsai.PulsePal/ParameterCode.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace Bonsai.PulsePal
+﻿namespace Bonsai.PulsePal
 {
     public enum ParameterCode : byte
     {

--- a/Bonsai.PulsePal/PulsePal.cs
+++ b/Bonsai.PulsePal/PulsePal.cs
@@ -1,9 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.IO.Ports;
-using System.Threading;
 using System.IO;
 
 namespace Bonsai.PulsePal

--- a/Bonsai.PulsePal/PulsePal.cs
+++ b/Bonsai.PulsePal/PulsePal.cs
@@ -8,7 +8,7 @@ using System.IO;
 
 namespace Bonsai.PulsePal
 {
-    sealed class PulsePal : IDisposable
+    public sealed class PulsePal : IDisposable
     {
         public const int BaudRate = 115200;
         const int MaxDataBytes = 35;

--- a/Bonsai.PulsePal/PulsePalConfiguration.cs
+++ b/Bonsai.PulsePal/PulsePalConfiguration.cs
@@ -1,10 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.ComponentModel;
+﻿using System.ComponentModel;
 using Bonsai.IO;
-using System.Collections.ObjectModel;
 
 namespace Bonsai.PulsePal
 {

--- a/Bonsai.PulsePal/PulsePalConfiguration.cs
+++ b/Bonsai.PulsePal/PulsePalConfiguration.cs
@@ -10,6 +10,8 @@ namespace Bonsai.PulsePal
 {
     public class PulsePalConfiguration
     {
+        internal static readonly PulsePalConfiguration Default = new PulsePalConfiguration();
+
         readonly ChannelParameterCollection channelParameters = new ChannelParameterCollection();
 
         [Description("The name of the serial port.")]

--- a/Bonsai.PulsePal/PulsePalConfigurationCollection.cs
+++ b/Bonsai.PulsePal/PulsePalConfigurationCollection.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Collections.ObjectModel;
+﻿using System.Collections.ObjectModel;
 using System.Xml.Serialization;
 
 namespace Bonsai.PulsePal

--- a/Bonsai.PulsePal/PulsePalDisposable.cs
+++ b/Bonsai.PulsePal/PulsePalDisposable.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Reactive.Disposables;
 

--- a/Bonsai.PulsePal/PulsePalManager.cs
+++ b/Bonsai.PulsePal/PulsePalManager.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Xml.Serialization;
 using System.Xml;
 using System.IO;

--- a/Bonsai.PulsePal/PulsePalManager.cs
+++ b/Bonsai.PulsePal/PulsePalManager.cs
@@ -9,18 +9,18 @@ using System.Threading.Tasks;
 
 namespace Bonsai.PulsePal
 {
-    internal static class PulsePalManager
+    public static class PulsePalManager
     {
         public const string DefaultConfigurationFile = "PulsePal.config";
         static readonly Dictionary<string, Tuple<PulsePal, RefCountDisposable>> openConnections = new Dictionary<string, Tuple<PulsePal, RefCountDisposable>>();
         static readonly object openConnectionsLock = new object();
 
-        public static PulsePalDisposable ReserveConnection(string portName)
+        internal static PulsePalDisposable ReserveConnection(string portName)
         {
             return ReserveConnection(portName, PulsePalConfiguration.Default);
         }
 
-        public static async Task<PulsePalDisposable> ReserveConnectionAsync(string portName)
+        internal static async Task<PulsePalDisposable> ReserveConnectionAsync(string portName)
         {
             return await Task.Run(() => ReserveConnection(portName, PulsePalConfiguration.Default));
         }
@@ -32,12 +32,13 @@ namespace Bonsai.PulsePal
             {
                 if (string.IsNullOrEmpty(portName))
                 {
-                    if (!string.IsNullOrEmpty(pulsePalConfiguration.PortName)) portName = pulsePalConfiguration.PortName; // override the port name if the configuration has already provided one
+                    if (!string.IsNullOrEmpty(pulsePalConfiguration.PortName)) portName = pulsePalConfiguration.PortName;
                     else if (openConnections.Count == 1) connection = openConnections.Values.Single();
                     else throw new ArgumentException("An alias or serial port name must be specified.", nameof(portName));
                 }
 
-                if (connection == null && !openConnections.TryGetValue(portName, out connection)) {
+                if (connection == null && !openConnections.TryGetValue(portName, out connection))
+                {
                     var serialPortName = pulsePalConfiguration.PortName;
                     if (string.IsNullOrEmpty(serialPortName)) serialPortName = portName;
 

--- a/Bonsai.PulsePal/TriggerOutput.cs
+++ b/Bonsai.PulsePal/TriggerOutput.cs
@@ -1,12 +1,7 @@
-﻿using Bonsai.IO;
-using System;
-using System.Collections.Generic;
+﻿using System;
 using System.ComponentModel;
 using System.Drawing.Design;
-using System.Linq;
 using System.Reactive.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Bonsai.PulsePal
 {

--- a/Bonsai.PulsePal/UpdatePulseTrain.cs
+++ b/Bonsai.PulsePal/UpdatePulseTrain.cs
@@ -6,7 +6,7 @@ using System.Reactive.Linq;
 
 namespace Bonsai.PulsePal
 {
-    [Description("Uploads a custom pulse train to the PulsePal.")]
+    [Description("Uploads a custom pulse train to the Pulse Pal.")]
     public class UpdatePulseTrain : Sink<Mat>
     {
         const int CycleTimeMicroseconds = 50;

--- a/Bonsai.PulsePal/UpdatePulseTrain.cs
+++ b/Bonsai.PulsePal/UpdatePulseTrain.cs
@@ -1,13 +1,8 @@
-﻿using Bonsai.IO;
-using OpenCV.Net;
+﻿using OpenCV.Net;
 using System;
-using System.Collections.Generic;
 using System.ComponentModel;
 using System.Drawing.Design;
-using System.Linq;
 using System.Reactive.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Bonsai.PulsePal
 {


### PR DESCRIPTION
The original package depended on local config files to parameterize the device. This PR moves the properties of the config file to an explicit `CreatePulsePal` operator, in keeping with the more modern pattern adopted in the standard library.

Fixes #4 
Fixes #5 