### PR TITLE
Add support for configuring single channel parameters

### DIFF
--- a/Bonsai.PulsePal/CombinatorTypeConverter.cs
+++ b/Bonsai.PulsePal/CombinatorTypeConverter.cs
@@ -1,0 +1,87 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Globalization;
+using System.Linq;
+using System.Reflection;
+using System.Xml.Serialization;
+
+namespace Bonsai.PulsePal
+{
+    class CombinatorTypeConverter : TypeConverter
+    {
+        internal static IEnumerable<Type> GetInstanceTypes(ITypeDescriptorContext context)
+        {
+            var builderType = context.Instance?.GetType() ?? context.PropertyDescriptor.ComponentType;
+            var includeAttributes = (XmlIncludeAttribute[])builderType.GetCustomAttributes(typeof(XmlIncludeAttribute), inherit: true);
+            if (includeAttributes.Length > 0)
+            {
+                return includeAttributes.Select(attribute => attribute.Type);
+            }
+
+            var propertyInfo = builderType.GetProperty(context.PropertyDescriptor.Name);
+            if (propertyInfo == null) return Enumerable.Empty<Type>();
+
+            var elementAttributes = (XmlElementAttribute[])propertyInfo.GetCustomAttributes(typeof(XmlElementAttribute), inherit: true);
+            if (elementAttributes.Length > 0)
+            {
+                return elementAttributes.Select(attribute => attribute.Type);
+            }
+
+            return propertyInfo.PropertyType.GetCustomAttributes<XmlIncludeAttribute>().Select(attribute => attribute.Type);
+        }
+
+        static string GetDisplayName(Type type)
+        {
+            var displayNameAttribute = (DisplayNameAttribute)type.GetCustomAttribute(typeof(DisplayNameAttribute));
+            if (!string.IsNullOrEmpty(displayNameAttribute?.DisplayName))
+            {
+                return displayNameAttribute.DisplayName;
+            }
+
+            return type.Name;
+        }
+
+        public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+        {
+            return sourceType == typeof(string);
+        }
+
+        public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
+        {
+            if (value is string typeName)
+            {
+                return GetInstanceTypes(context).FirstOrDefault(
+                    type => string.Equals(GetDisplayName(type), typeName, StringComparison.OrdinalIgnoreCase));
+            }
+
+            return null;
+        }
+
+        public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
+        {
+            if (destinationType == typeof(string) && value is Type valueType)
+            {
+                return GetDisplayName(valueType);
+            }
+
+            return null;
+        }
+
+        public override bool GetStandardValuesSupported(ITypeDescriptorContext context)
+        {
+            return true;
+        }
+
+        public override bool GetStandardValuesExclusive(ITypeDescriptorContext context)
+        {
+            return true;
+        }
+
+        public override StandardValuesCollection GetStandardValues(ITypeDescriptorContext context)
+        {
+            var includeTypes = GetInstanceTypes(context).ToArray();
+            return new StandardValuesCollection(includeTypes);
+        }
+    }
+}

--- a/Bonsai.PulsePal/Configuration/BiphasicConfiguration.cs
+++ b/Bonsai.PulsePal/Configuration/BiphasicConfiguration.cs
@@ -1,0 +1,25 @@
+﻿using System.ComponentModel;
+
+namespace Bonsai.PulsePal
+{
+    /// <summary>
+    /// Represents configuration parameters specifying whether the channel
+    /// will produce either monophasic or biphasic square pulses.
+    /// </summary>
+    [DisplayName(nameof(ParameterCode.Biphasic))]
+    public class BiphasicConfiguration : OutputChannelParameterConfiguration
+    {
+        /// <summary>
+        /// Gets or sets a value specifying whether to use biphasic or
+        /// monophasic pulses.
+        /// </summary>
+        [Description("Specifies whether to use biphasic or monophasic pulses.")]
+        public bool Biphasic { get; set; }
+
+        /// <inheritdoc/>
+        public override void Configure(PulsePal device)
+        {
+            device.SetBiphasic(Channel, Biphasic);
+        }
+    }
+}

--- a/Bonsai.PulsePal/Configuration/BurstDurationConfiguration.cs
+++ b/Bonsai.PulsePal/Configuration/BurstDurationConfiguration.cs
@@ -1,0 +1,28 @@
+﻿using System.ComponentModel;
+
+namespace Bonsai.PulsePal
+{
+    /// <summary>
+    /// Represents configuration parameters specifying the duration of a pulse
+    /// burst when using burst mode.
+    /// </summary>
+    [DisplayName(nameof(ParameterCode.BurstDuration))]
+    public class BurstDurationConfiguration : OutputChannelParameterConfiguration
+    {
+        /// <summary>
+        /// Gets or sets the duration of a pulse burst, in the range
+        /// [0.0001, 3600] seconds.
+        /// </summary>
+        [Range(MinTimePeriod, MaxTimePeriod)]
+        [Precision(TimeDecimalPlaces, MinTimePeriod)]
+        [Editor(DesignTypes.SliderEditor, DesignTypes.UITypeEditor)]
+        [Description("The duration of a pulse burst, in seconds.")]
+        public double BurstDuration { get; set; } = MinTimePeriod;
+
+        /// <inheritdoc/>
+        public override void Configure(PulsePal device)
+        {
+            device.SetBurstDuration(Channel, BurstDuration);
+        }
+    }
+}

--- a/Bonsai.PulsePal/Configuration/ChannelParameterConfiguration.cs
+++ b/Bonsai.PulsePal/Configuration/ChannelParameterConfiguration.cs
@@ -1,0 +1,16 @@
+﻿namespace Bonsai.PulsePal
+{
+    /// <summary>
+    /// Provides an abstract base class for configuring Pulse Pal
+    /// channel parameters.
+    /// </summary>
+    public abstract class ChannelParameterConfiguration
+    {
+        /// <summary>
+        /// Applies the channel parameter configuration to the specified
+        /// Pulse Pal device.
+        /// </summary>
+        /// <param name="device">The Pulse Pal device to configure.</param>
+        public abstract void Configure(PulsePal device);
+    }
+}

--- a/Bonsai.PulsePal/Configuration/CustomTrainIdentityConfiguration.cs
+++ b/Bonsai.PulsePal/Configuration/CustomTrainIdentityConfiguration.cs
@@ -1,0 +1,25 @@
+﻿using System.ComponentModel;
+
+namespace Bonsai.PulsePal
+{
+    /// <summary>
+    /// Represents configuration parameters specifying the identity of the custom
+    /// train used to specify pulse times and voltages on an output channel.
+    /// </summary>
+    [DisplayName(nameof(ParameterCode.CustomTrainIdentity))]
+    public class CustomTrainIdentityConfiguration : OutputChannelParameterConfiguration
+    {
+        /// <summary>
+        /// Gets or sets a value specifying the identity of the custom pulse train
+        /// to use on this output channel.
+        /// </summary>
+        [Description("Specifies the identity of the custom pulse train to use on this output channel.")]
+        public CustomTrainId CustomTrainIdentity { get; set; }
+
+        /// <inheritdoc/>
+        public override void Configure(PulsePal device)
+        {
+            device.SetCustomTrainIdentity(Channel, CustomTrainIdentity);
+        }
+    }
+}

--- a/Bonsai.PulsePal/Configuration/CustomTrainLoopConfiguration.cs
+++ b/Bonsai.PulsePal/Configuration/CustomTrainLoopConfiguration.cs
@@ -1,0 +1,25 @@
+﻿using System.ComponentModel;
+
+namespace Bonsai.PulsePal
+{
+    /// <summary>
+    /// Represents configuration parameters specifying whether the output channel
+    /// will loop its custom pulse train.
+    /// </summary>
+    [DisplayName(nameof(ParameterCode.CustomTrainLoop))]
+    public class CustomTrainLoopConfiguration : OutputChannelParameterConfiguration
+    {
+        /// <summary>
+        /// Gets or sets a value specifying whether the output channel
+        /// will loop its custom pulse train.
+        /// </summary>
+        [Description("Specifies whether the output channel will loop its custom pulse train.")]
+        public bool CustomTrainLoop { get; set; }
+
+        /// <inheritdoc/>
+        public override void Configure(PulsePal device)
+        {
+            device.SetCustomTrainLoop(Channel, CustomTrainLoop);
+        }
+    }
+}

--- a/Bonsai.PulsePal/Configuration/CustomTrainTargetConfiguration.cs
+++ b/Bonsai.PulsePal/Configuration/CustomTrainTargetConfiguration.cs
@@ -1,0 +1,25 @@
+﻿using System.ComponentModel;
+
+namespace Bonsai.PulsePal
+{
+    /// <summary>
+    /// Represents configuration parameters specifying the interpretation of pulse times
+    /// in the custom train configured on this output channel.
+    /// </summary>
+    [DisplayName(nameof(ParameterCode.CustomTrainTarget))]
+    public class CustomTrainTargetConfiguration : OutputChannelParameterConfiguration
+    {
+        /// <summary>
+        /// Gets or sets a value specifying the interpretation of pulse times in the
+        /// custom pulse train.
+        /// </summary>
+        [Description("Specifies the interpretation of pulse times in the custom pulse train.")]
+        public CustomTrainTarget CustomTrainTarget { get; set; }
+
+        /// <inheritdoc/>
+        public override void Configure(PulsePal device)
+        {
+            device.SetCustomTrainTarget(Channel, CustomTrainTarget);
+        }
+    }
+}

--- a/Bonsai.PulsePal/Configuration/InterBurstIntervalConfiguration.cs
+++ b/Bonsai.PulsePal/Configuration/InterBurstIntervalConfiguration.cs
@@ -1,0 +1,28 @@
+﻿using System.ComponentModel;
+
+namespace Bonsai.PulsePal
+{
+    /// <summary>
+    /// Represents configuration parameters specifying the duration of the
+    /// off-time between bursts.
+    /// </summary>
+    [DisplayName(nameof(ParameterCode.InterBurstInterval))]
+    public class InterBurstIntervalConfiguration : OutputChannelParameterConfiguration
+    {
+        /// <summary>
+        /// Gets or sets the duration of the off-time between bursts, in the range
+        /// [0.0001, 3600] seconds.
+        /// </summary>
+        [Range(MinTimePeriod, MaxTimePeriod)]
+        [Precision(TimeDecimalPlaces, MinTimePeriod)]
+        [Editor(DesignTypes.SliderEditor, DesignTypes.UITypeEditor)]
+        [Description("The duration of the off-time between bursts, in seconds.")]
+        public double InterBurstInterval { get; set; } = MinTimePeriod;
+
+        /// <inheritdoc/>
+        public override void Configure(PulsePal device)
+        {
+            device.SetInterBurstInterval(Channel, InterBurstInterval);
+        }
+    }
+}

--- a/Bonsai.PulsePal/Configuration/InterPhaseIntervalConfiguration.cs
+++ b/Bonsai.PulsePal/Configuration/InterPhaseIntervalConfiguration.cs
@@ -1,0 +1,28 @@
+﻿using System.ComponentModel;
+
+namespace Bonsai.PulsePal
+{
+    /// <summary>
+    /// Represents configuration parameters specifying the interval between the first
+    /// and second phases of biphasic pulses.
+    /// </summary>
+    [DisplayName(nameof(ParameterCode.InterPhaseInterval))]
+    public class InterPhaseIntervalConfiguration : OutputChannelParameterConfiguration
+    {
+        /// <summary>
+        /// Gets or sets the interval between the first and second phase of a biphasic pulse,
+        /// in the range [0.0001, 3600] seconds.
+        /// </summary>
+        [Range(MinTimePeriod, MaxTimePeriod)]
+        [Precision(TimeDecimalPlaces, MinTimePeriod)]
+        [Editor(DesignTypes.SliderEditor, DesignTypes.UITypeEditor)]
+        [Description("The interval between the first and second phase of a biphasic pulse, in seconds.")]
+        public double InterPhaseInterval { get; set; } = MinTimePeriod;
+
+        /// <inheritdoc/>
+        public override void Configure(PulsePal device)
+        {
+            device.SetInterPhaseInterval(Channel, InterPhaseInterval);
+        }
+    }
+}

--- a/Bonsai.PulsePal/Configuration/InterPulseIntervalConfiguration.cs
+++ b/Bonsai.PulsePal/Configuration/InterPulseIntervalConfiguration.cs
@@ -1,0 +1,26 @@
+﻿using System.ComponentModel;
+
+namespace Bonsai.PulsePal
+{
+    /// <summary>
+    /// Represents configuration parameters specifying the interval between pulses.
+    /// </summary>
+    [DisplayName(nameof(ParameterCode.InterPulseInterval))]
+    public class InterPulseIntervalConfiguration : OutputChannelParameterConfiguration
+    {
+        /// <summary>
+        /// Gets or sets the interval between pulses, in the range [0.0001, 3600] seconds.
+        /// </summary>
+        [Range(MinTimePeriod, MaxTimePeriod)]
+        [Precision(TimeDecimalPlaces, MinTimePeriod)]
+        [Editor(DesignTypes.SliderEditor, DesignTypes.UITypeEditor)]
+        [Description("The interval between pulses, in seconds.")]
+        public double InterPulseInterval { get; set; } = MinTimePeriod;
+
+        /// <inheritdoc/>
+        public override void Configure(PulsePal device)
+        {
+            device.SetInterPulseInterval(Channel, InterPulseInterval);
+        }
+    }
+}

--- a/Bonsai.PulsePal/Configuration/OutputChannelParameterConfiguration.cs
+++ b/Bonsai.PulsePal/Configuration/OutputChannelParameterConfiguration.cs
@@ -3,9 +3,10 @@
 namespace Bonsai.PulsePal
 {
     /// <summary>
-    /// Provides an abstract base class for Pulse Pal channel parameters.
+    /// Provides an abstract base class for configuring Pulse Pal
+    /// output channel parameters.
     /// </summary>
-    public abstract class OutputChannelParameterConfiguration
+    public abstract class OutputChannelParameterConfiguration : ChannelParameterConfiguration
     {
         internal const double MinVoltage = -10;
         internal const double MaxVoltage = 10;
@@ -20,12 +21,5 @@ namespace Bonsai.PulsePal
         /// </summary>
         [Description("Specifies the output channel to configure.")]
         public OutputChannel Channel { get; set; } = OutputChannel.Channel1;
-
-        /// <summary>
-        /// Applies the channel parameter configuration to the specified
-        /// Pulse Pal device.
-        /// </summary>
-        /// <param name="device">The Pulse Pal device to configure.</param>
-        public abstract void Configure(PulsePal device);
     }
 }

--- a/Bonsai.PulsePal/Configuration/OutputChannelParameterConfiguration.cs
+++ b/Bonsai.PulsePal/Configuration/OutputChannelParameterConfiguration.cs
@@ -1,0 +1,32 @@
+﻿using System.ComponentModel;
+using System.Xml.Serialization;
+
+namespace Bonsai.PulsePal
+{
+    /// <summary>
+    /// Provides an abstract base class for Pulse Pal channel parameters.
+    /// </summary>
+    public abstract class OutputChannelParameterConfiguration
+    {
+        internal const double MinVoltage = -10;
+        internal const double MaxVoltage = 10;
+        internal const int VoltageDecimalPlaces = 3;
+        internal const double VoltageIncrement = 0.001;
+        internal const double MinTimePeriod = 0.0001;
+        internal const double MaxTimePeriod = 3600;
+        internal const int TimeDecimalPlaces = 4;
+
+        /// <summary>
+        /// Gets or sets a value specifying the output channel to configure.
+        /// </summary>
+        [Description("Specifies the output channel to configure.")]
+        public OutputChannel Channel { get; set; } = OutputChannel.Channel1;
+
+        /// <summary>
+        /// Applies the channel parameter configuration to the specified
+        /// Pulse Pal device.
+        /// </summary>
+        /// <param name="device">The Pulse Pal device to configure.</param>
+        public abstract void Configure(PulsePal device);
+    }
+}

--- a/Bonsai.PulsePal/Configuration/OutputChannelParameterConfiguration.cs
+++ b/Bonsai.PulsePal/Configuration/OutputChannelParameterConfiguration.cs
@@ -1,5 +1,4 @@
 ﻿using System.ComponentModel;
-using System.Xml.Serialization;
 
 namespace Bonsai.PulsePal
 {

--- a/Bonsai.PulsePal/Configuration/Phase1DurationConfiguration.cs
+++ b/Bonsai.PulsePal/Configuration/Phase1DurationConfiguration.cs
@@ -1,0 +1,28 @@
+﻿using System.ComponentModel;
+
+namespace Bonsai.PulsePal
+{
+    /// <summary>
+    /// Represents configuration parameters specifying the duration for the first
+    /// phase of each pulse.
+    /// </summary>
+    [DisplayName(nameof(ParameterCode.Phase1Duration))]
+    public class Phase1DurationConfiguration : OutputChannelParameterConfiguration
+    {
+        /// <summary>
+        /// Gets or sets the duration of the first phase of the pulse, in the range
+        /// [0.0001, 3600] seconds.
+        /// </summary>
+        [Range(MinTimePeriod, MaxTimePeriod)]
+        [Precision(TimeDecimalPlaces, MinTimePeriod)]
+        [Editor(DesignTypes.SliderEditor, DesignTypes.UITypeEditor)]
+        [Description("The duration of the first phase of the pulse, in seconds.")]
+        public double Phase1Duration { get; set; } = MinTimePeriod;
+
+        /// <inheritdoc/>
+        public override void Configure(PulsePal device)
+        {
+            device.SetPhase1Duration(Channel, Phase1Duration);
+        }
+    }
+}

--- a/Bonsai.PulsePal/Configuration/Phase1VoltageConfiguration.cs
+++ b/Bonsai.PulsePal/Configuration/Phase1VoltageConfiguration.cs
@@ -1,0 +1,27 @@
+﻿using System.ComponentModel;
+
+namespace Bonsai.PulsePal
+{
+    /// <summary>
+    /// Represents configuration parameters specifying the voltage for the first
+    /// phase of each pulse.
+    /// </summary>
+    [DisplayName(nameof(ParameterCode.Phase1Voltage))]
+    public class Phase1VoltageConfiguration : OutputChannelParameterConfiguration
+    {
+        /// <summary>
+        /// Gets or sets the voltage for the first phase of each pulse.
+        /// </summary>
+        [Range(MinVoltage, MaxVoltage)]
+        [Precision(VoltageDecimalPlaces, VoltageIncrement)]
+        [Editor(DesignTypes.SliderEditor, DesignTypes.UITypeEditor)]
+        [Description("The voltage for the first phase of each pulse.")]
+        public double Phase1Voltage { get; set; }
+
+        /// <inheritdoc/>
+        public override void Configure(PulsePal device)
+        {
+            device.SetPhase1Voltage(Channel, Phase1Voltage);
+        }
+    }
+}

--- a/Bonsai.PulsePal/Configuration/Phase2DurationConfiguration.cs
+++ b/Bonsai.PulsePal/Configuration/Phase2DurationConfiguration.cs
@@ -1,0 +1,28 @@
+﻿using System.ComponentModel;
+
+namespace Bonsai.PulsePal
+{
+    /// <summary>
+    /// Represents configuration parameters specifying the duration for the second
+    /// phase of each pulse.
+    /// </summary>
+    [DisplayName(nameof(ParameterCode.Phase2Duration))]
+    public class Phase2DurationConfiguration : OutputChannelParameterConfiguration
+    {
+        /// <summary>
+        /// Gets or sets the duration of the second phase of the pulse, in the range
+        /// [0.0001, 3600] seconds.
+        /// </summary>
+        [Range(MinTimePeriod, MaxTimePeriod)]
+        [Precision(TimeDecimalPlaces, MinTimePeriod)]
+        [Editor(DesignTypes.SliderEditor, DesignTypes.UITypeEditor)]
+        [Description("The duration of the second phase of the pulse, in seconds.")]
+        public double Phase2Duration { get; set; } = MinTimePeriod;
+
+        /// <inheritdoc/>
+        public override void Configure(PulsePal device)
+        {
+            device.SetPhase2Duration(Channel, Phase2Duration);
+        }
+    }
+}

--- a/Bonsai.PulsePal/Configuration/Phase2VoltageConfiguration.cs
+++ b/Bonsai.PulsePal/Configuration/Phase2VoltageConfiguration.cs
@@ -1,0 +1,27 @@
+﻿using System.ComponentModel;
+
+namespace Bonsai.PulsePal
+{
+    /// <summary>
+    /// Represents configuration parameters specifying the voltage for the second
+    /// phase of each pulse.
+    /// </summary>
+    [DisplayName(nameof(ParameterCode.Phase2Voltage))]
+    public class Phase2VoltageConfiguration : OutputChannelParameterConfiguration
+    {
+        /// <summary>
+        /// Gets or sets the voltage for the second phase of each pulse.
+        /// </summary>
+        [Range(MinVoltage, MaxVoltage)]
+        [Precision(VoltageDecimalPlaces, VoltageIncrement)]
+        [Editor(DesignTypes.SliderEditor, DesignTypes.UITypeEditor)]
+        [Description("The voltage for the second phase of each pulse.")]
+        public double Phase2Voltage { get; set; }
+
+        /// <inheritdoc/>
+        public override void Configure(PulsePal device)
+        {
+            device.SetPhase2Voltage(Channel, Phase2Voltage);
+        }
+    }
+}

--- a/Bonsai.PulsePal/Configuration/PulseTrainDelayConfiguration.cs
+++ b/Bonsai.PulsePal/Configuration/PulseTrainDelayConfiguration.cs
@@ -1,0 +1,28 @@
+﻿using System.ComponentModel;
+
+namespace Bonsai.PulsePal
+{
+    /// <summary>
+    /// Represents configuration parameters specifying a delay between the arrival of
+    /// a trigger and when the channel begins its pulse train.
+    /// </summary>
+    [DisplayName(nameof(ParameterCode.PulseTrainDelay))]
+    public class PulseTrainDelayConfiguration : OutputChannelParameterConfiguration
+    {
+        /// <summary>
+        /// Gets or sets the delay to start the pulse train, in the range
+        /// [0.0001, 3600] seconds.
+        /// </summary>
+        [Range(MinTimePeriod, MaxTimePeriod)]
+        [Precision(TimeDecimalPlaces, MinTimePeriod)]
+        [Editor(DesignTypes.SliderEditor, DesignTypes.UITypeEditor)]
+        [Description("The delay to start the pulse train, in seconds.")]
+        public double PulseTrainDelay { get; set; } = MinTimePeriod;
+
+        /// <inheritdoc/>
+        public override void Configure(PulsePal device)
+        {
+            device.SetPulseTrainDelay(Channel, PulseTrainDelay);
+        }
+    }
+}

--- a/Bonsai.PulsePal/Configuration/PulseTrainDurationConfiguration.cs
+++ b/Bonsai.PulsePal/Configuration/PulseTrainDurationConfiguration.cs
@@ -1,0 +1,28 @@
+﻿using System.ComponentModel;
+
+namespace Bonsai.PulsePal
+{
+    /// <summary>
+    /// Represents configuration parameters specifying the duration of the
+    /// entire pulse train.
+    /// </summary>
+    [DisplayName(nameof(ParameterCode.PulseTrainDuration))]
+    public class PulseTrainDurationConfiguration : OutputChannelParameterConfiguration
+    {
+        /// <summary>
+        /// Gets or sets the duration of the pulse train, in the range
+        /// [0.0001, 3600] seconds.
+        /// </summary>
+        [Range(MinTimePeriod, MaxTimePeriod)]
+        [Precision(TimeDecimalPlaces, MinTimePeriod)]
+        [Editor(DesignTypes.SliderEditor, DesignTypes.UITypeEditor)]
+        [Description("The duration of the pulse train, in seconds.")]
+        public double PulseTrainDuration { get; set; } = MinTimePeriod;
+
+        /// <inheritdoc/>
+        public override void Configure(PulsePal device)
+        {
+            device.SetPulseTrainDuration(Channel, PulseTrainDuration);
+        }
+    }
+}

--- a/Bonsai.PulsePal/Configuration/RestingVoltageConfiguration.cs
+++ b/Bonsai.PulsePal/Configuration/RestingVoltageConfiguration.cs
@@ -1,0 +1,27 @@
+﻿using System.ComponentModel;
+
+namespace Bonsai.PulsePal
+{
+    /// <summary>
+    /// Represents configuration parameters specifying the resting voltage on this
+    /// output channel, i.e. the voltage between phases, pulses and pulse trains.
+    /// </summary>
+    [DisplayName(nameof(ParameterCode.RestingVoltage))]
+    public class RestingVoltageConfiguration : OutputChannelParameterConfiguration
+    {
+        /// <summary>
+        /// Gets or sets the resting voltage, in the range [-10, 10] volts.
+        /// </summary>
+        [Range(MinVoltage, MaxVoltage)]
+        [Precision(VoltageDecimalPlaces, VoltageIncrement)]
+        [Editor(DesignTypes.SliderEditor, DesignTypes.UITypeEditor)]
+        [Description("The resting voltage.")]
+        public double RestingVoltage { get; set; }
+
+        /// <inheritdoc/>
+        public override void Configure(PulsePal device)
+        {
+            device.SetRestingVoltage(Channel, RestingVoltage);
+        }
+    }
+}

--- a/Bonsai.PulsePal/Configuration/TriggerChannelParameterConfiguration.cs
+++ b/Bonsai.PulsePal/Configuration/TriggerChannelParameterConfiguration.cs
@@ -1,0 +1,24 @@
+﻿using System.ComponentModel;
+using System.Xml.Serialization;
+
+namespace Bonsai.PulsePal
+{
+    /// <summary>
+    /// Provides an abstract base class for Pulse Pal channel parameters.
+    /// </summary>
+    public abstract class TriggerChannelParameterConfiguration
+    {
+        /// <summary>
+        /// Gets or sets a value specifying the output channel to configure.
+        /// </summary>
+        [Description("Specifies the output channel to configure.")]
+        public TriggerChannel Channel { get; set; } = TriggerChannel.Channel1;
+
+        /// <summary>
+        /// Applies the channel parameter configuration to the specified
+        /// Pulse Pal device.
+        /// </summary>
+        /// <param name="device">The Pulse Pal device to configure.</param>
+        public abstract void Configure(PulsePal device);
+    }
+}

--- a/Bonsai.PulsePal/Configuration/TriggerChannelParameterConfiguration.cs
+++ b/Bonsai.PulsePal/Configuration/TriggerChannelParameterConfiguration.cs
@@ -3,21 +3,15 @@
 namespace Bonsai.PulsePal
 {
     /// <summary>
-    /// Provides an abstract base class for Pulse Pal channel parameters.
+    /// Provides an abstract base class for configuring Pulse Pal
+    /// trigger channel parameters.
     /// </summary>
-    public abstract class TriggerChannelParameterConfiguration
+    public abstract class TriggerChannelParameterConfiguration : ChannelParameterConfiguration
     {
         /// <summary>
         /// Gets or sets a value specifying the output channel to configure.
         /// </summary>
         [Description("Specifies the output channel to configure.")]
         public TriggerChannel Channel { get; set; } = TriggerChannel.Channel1;
-
-        /// <summary>
-        /// Applies the channel parameter configuration to the specified
-        /// Pulse Pal device.
-        /// </summary>
-        /// <param name="device">The Pulse Pal device to configure.</param>
-        public abstract void Configure(PulsePal device);
     }
 }

--- a/Bonsai.PulsePal/Configuration/TriggerChannelParameterConfiguration.cs
+++ b/Bonsai.PulsePal/Configuration/TriggerChannelParameterConfiguration.cs
@@ -1,5 +1,4 @@
 ﻿using System.ComponentModel;
-using System.Xml.Serialization;
 
 namespace Bonsai.PulsePal
 {

--- a/Bonsai.PulsePal/Configuration/TriggerModeConfiguration.cs
+++ b/Bonsai.PulsePal/Configuration/TriggerModeConfiguration.cs
@@ -1,0 +1,23 @@
+﻿using System.ComponentModel;
+
+namespace Bonsai.PulsePal
+{
+    /// <summary>
+    /// Represents configuration parameters specifying the behavior of a trigger channel.
+    /// </summary>
+    [DisplayName(nameof(ParameterCode.TriggerMode))]
+    public class TriggerModeConfiguration : TriggerChannelParameterConfiguration
+    {
+        /// <summary>
+        /// Gets or sets a value specifying the behavior of a trigger channel.
+        /// </summary>
+        [Description("Specifies the behavior of a trigger channel.")]
+        public TriggerMode TriggerMode { get; set; }
+
+        /// <inheritdoc/>
+        public override void Configure(PulsePal device)
+        {
+            device.SetTriggerMode(Channel, TriggerMode);
+        }
+    }
+}

--- a/Bonsai.PulsePal/Configuration/TriggerOnChannel1Configuration.cs
+++ b/Bonsai.PulsePal/Configuration/TriggerOnChannel1Configuration.cs
@@ -1,0 +1,25 @@
+﻿using System.ComponentModel;
+
+namespace Bonsai.PulsePal
+{
+    /// <summary>
+    /// Represents configuration parameters specifying whether trigger channel 1 can
+    /// trigger the output channel.
+    /// </summary>
+    [DisplayName(nameof(ParameterCode.TriggerOnChannel1))]
+    public class TriggerOnChannel1Configuration : OutputChannelParameterConfiguration
+    {
+        /// <summary>
+        /// Gets or sets a value specifying whether trigger channel 1 can trigger
+        /// this output channel.
+        /// </summary>
+        [Description("Specifies whether trigger channel 1 can trigger this output channel.")]
+        public bool TriggerOnChannel1 { get; set; }
+
+        /// <inheritdoc/>
+        public override void Configure(PulsePal device)
+        {
+            device.SetTriggerOnChannel1(Channel, TriggerOnChannel1);
+        }
+    }
+}

--- a/Bonsai.PulsePal/Configuration/TriggerOnChannel2Configuration.cs
+++ b/Bonsai.PulsePal/Configuration/TriggerOnChannel2Configuration.cs
@@ -1,0 +1,25 @@
+﻿using System.ComponentModel;
+
+namespace Bonsai.PulsePal
+{
+    /// <summary>
+    /// Represents configuration parameters specifying whether trigger channel 2 can
+    /// trigger the output channel.
+    /// </summary>
+    [DisplayName(nameof(ParameterCode.TriggerOnChannel2))]
+    public class TriggerOnChannel2Configuration : OutputChannelParameterConfiguration
+    {
+        /// <summary>
+        /// Gets or sets a value specifying whether trigger channel 2 can trigger
+        /// this output channel.
+        /// </summary>
+        [Description("Specifies whether trigger channel 2 can trigger this output channel.")]
+        public bool TriggerOnChannel2 { get; set; }
+
+        /// <inheritdoc/>
+        public override void Configure(PulsePal device)
+        {
+            device.SetTriggerOnChannel2(Channel, TriggerOnChannel2);
+        }
+    }
+}

--- a/Bonsai.PulsePal/ConfigureChannelParameter.cs
+++ b/Bonsai.PulsePal/ConfigureChannelParameter.cs
@@ -1,0 +1,69 @@
+﻿using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Xml.Serialization;
+
+namespace Bonsai.PulsePal
+{
+    /// <summary>
+    /// Represents an operator that configures a single channel parameter on a
+    /// Pulse Pal device.
+    /// </summary>
+    [DefaultProperty(nameof(Parameter))]
+    [XmlInclude(typeof(BiphasicConfiguration))]
+    [XmlInclude(typeof(Phase1VoltageConfiguration))]
+    [XmlInclude(typeof(Phase2VoltageConfiguration))]
+    [XmlInclude(typeof(Phase1DurationConfiguration))]
+    [XmlInclude(typeof(InterPhaseIntervalConfiguration))]
+    [XmlInclude(typeof(Phase2DurationConfiguration))]
+    [XmlInclude(typeof(InterPulseIntervalConfiguration))]
+    [XmlInclude(typeof(BurstDurationConfiguration))]
+    [XmlInclude(typeof(InterBurstIntervalConfiguration))]
+    [XmlInclude(typeof(PulseTrainDurationConfiguration))]
+    [XmlInclude(typeof(PulseTrainDelayConfiguration))]
+    [XmlInclude(typeof(TriggerOnChannel1Configuration))]
+    [XmlInclude(typeof(TriggerOnChannel2Configuration))]
+    [XmlInclude(typeof(CustomTrainIdentityConfiguration))]
+    [XmlInclude(typeof(CustomTrainTargetConfiguration))]
+    [XmlInclude(typeof(CustomTrainLoopConfiguration))]
+    [XmlInclude(typeof(RestingVoltageConfiguration))]
+    [XmlInclude(typeof(TriggerModeConfiguration))]
+    [Description("Configures a single channel parameter on a Pulse Pal device.")]
+    public class ConfigureChannelParameter : PolymorphicCombinatorBuilder
+    {
+        static readonly Range<int> argumentRange = Range.Create(lowerBound: 1, upperBound: 1);
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ConfigureChannelParameter"/> class.
+        /// </summary>
+        public ConfigureChannelParameter()
+        {
+            Parameter = new BiphasicConfiguration();
+        }
+
+        /// <inheritdoc/>
+        public override Range<int> ArgumentRange => argumentRange;
+
+        /// <summary>
+        /// Gets or sets the operator used to configure specific Pulse Pal channel parameters.
+        /// </summary>
+        [DesignOnly(true)]
+        [Externalizable(false)]
+        [RefreshProperties(RefreshProperties.All)]
+        [Category(nameof(CategoryAttribute.Design))]
+        [Description("The operator used to configure specific Pulse Pal channel parameters.")]
+        [TypeConverter(typeof(CombinatorTypeConverter))]
+        public object Parameter
+        {
+            get { return Operator; }
+            set { Operator = value; }
+        }
+
+        /// <inheritdoc/>
+        public override Expression Build(IEnumerable<Expression> arguments)
+        {
+            return arguments.Single();
+        }
+    }
+}

--- a/Bonsai.PulsePal/ConfigureOutputChannel.cs
+++ b/Bonsai.PulsePal/ConfigureOutputChannel.cs
@@ -16,13 +16,13 @@ namespace Bonsai.PulsePal
         const string TimingCategory = "Pulse Timing";
         const string CustomTrainCategory = "Custom Train";
         const string TriggerCategory = "Pulse Trigger";
-        const double MinVoltage = -10;
-        const double MaxVoltage = 10;
-        const int VoltageDecimalPlaces = 3;
-        const double VoltageIncrement = 0.001;
-        const double MinTimePeriod = 0.0001;
-        const double MaxTimePeriod = 3600;
-        const int TimeDecimalPlaces = 4;
+        const double MinVoltage = OutputChannelParameterConfiguration.MinVoltage;
+        const double MaxVoltage = OutputChannelParameterConfiguration.MaxVoltage;
+        const int VoltageDecimalPlaces = OutputChannelParameterConfiguration.VoltageDecimalPlaces;
+        const double VoltageIncrement = OutputChannelParameterConfiguration.VoltageIncrement;
+        const double MinTimePeriod = OutputChannelParameterConfiguration.MinTimePeriod;
+        const double MaxTimePeriod = OutputChannelParameterConfiguration.MaxTimePeriod;
+        const int TimeDecimalPlaces = OutputChannelParameterConfiguration.TimeDecimalPlaces;
 
         string INamedElement.Name => Channel == 0
             ? nameof(ConfigureOutputChannel)

--- a/Bonsai.PulsePal/PolymorphicCombinator.cs
+++ b/Bonsai.PulsePal/PolymorphicCombinator.cs
@@ -1,15 +1,15 @@
 ﻿using System;
 using System.ComponentModel;
-using Bonsai.Expressions;
 
 namespace Bonsai.PulsePal
 {
     /// <summary>
-    /// Provides an abstract base class for polymorphic operators.
+    /// Provides an abstract base class for polymorphic combinators.
     /// </summary>
-    public abstract class PolymorphicCombinatorBuilder : ExpressionBuilder, ICustomTypeDescriptor
+    [Combinator]
+    public abstract class PolymorphicCombinator : ICustomTypeDescriptor
     {
-        internal PolymorphicCombinatorBuilder()
+        internal PolymorphicCombinator()
         {
         }
 

--- a/Bonsai.PulsePal/PolymorphicCombinatorBuilder.cs
+++ b/Bonsai.PulsePal/PolymorphicCombinatorBuilder.cs
@@ -1,0 +1,187 @@
+﻿using System;
+using System.ComponentModel;
+using Bonsai.Expressions;
+
+namespace Bonsai.PulsePal
+{
+    /// <summary>
+    /// Provides an abstract base class for polymorphic operators.
+    /// </summary>
+    public abstract class PolymorphicCombinatorBuilder : ExpressionBuilder, ICustomTypeDescriptor
+    {
+        internal PolymorphicCombinatorBuilder()
+        {
+        }
+
+        internal static string RemoveSuffix(string source, string suffix)
+        {
+            var suffixStart = source.LastIndexOf(suffix);
+            return suffixStart >= 0 ? source.Remove(suffixStart) : source;
+        }
+
+        internal object Operator { get; set; }
+
+        #region ICustomTypeDescriptor Members
+
+        static readonly Attribute[] EmptyAttributes = new Attribute[0];
+
+        AttributeCollection ICustomTypeDescriptor.GetAttributes()
+        {
+            var attributes = TypeDescriptor.GetAttributes(GetType());
+            var defaultProperty = TypeDescriptor.GetDefaultProperty(GetType());
+            if (defaultProperty != null)
+            {
+                var instance = defaultProperty.GetValue(this);
+                var instanceAttributes = TypeDescriptor.GetAttributes(instance);
+                if (instanceAttributes[typeof(DescriptionAttribute)] is DescriptionAttribute description)
+                {
+                    return AttributeCollection.FromExisting(attributes, description);
+                }
+            }
+
+            return attributes;
+        }
+
+        string ICustomTypeDescriptor.GetClassName()
+        {
+            return TypeDescriptor.GetClassName(GetType());
+        }
+
+        string ICustomTypeDescriptor.GetComponentName()
+        {
+            return null;
+        }
+
+        TypeConverter ICustomTypeDescriptor.GetConverter()
+        {
+            return TypeDescriptor.GetConverter(GetType());
+        }
+
+        EventDescriptor ICustomTypeDescriptor.GetDefaultEvent()
+        {
+            return null;
+        }
+
+        PropertyDescriptor ICustomTypeDescriptor.GetDefaultProperty()
+        {
+            var defaultProperty = TypeDescriptor.GetDefaultProperty(GetType());
+            return defaultProperty != null ? new FactoryTypePropertyDescriptor(defaultProperty) : null;
+        }
+
+        object ICustomTypeDescriptor.GetEditor(Type editorBaseType)
+        {
+            return TypeDescriptor.GetEditor(GetType(), editorBaseType);
+        }
+
+        EventDescriptorCollection ICustomTypeDescriptor.GetEvents()
+        {
+            return EventDescriptorCollection.Empty;
+        }
+
+        EventDescriptorCollection ICustomTypeDescriptor.GetEvents(Attribute[] attributes)
+        {
+            return EventDescriptorCollection.Empty;
+        }
+
+        PropertyDescriptorCollection ICustomTypeDescriptor.GetProperties()
+        {
+            return ((ICustomTypeDescriptor)this).GetProperties(EmptyAttributes);
+        }
+
+        PropertyDescriptorCollection ICustomTypeDescriptor.GetProperties(Attribute[] attributes)
+        {
+            var baseProperties = TypeDescriptor.GetProperties(GetType(), attributes);
+            var defaultProperty = TypeDescriptor.GetDefaultProperty(GetType());
+            if (defaultProperty != null)
+            {
+                var instance = defaultProperty.GetValue(this);
+                var instanceProperties = TypeDescriptor.GetProperties(instance, attributes);
+                var properties = new PropertyDescriptor[baseProperties.Count + instanceProperties.Count];
+                for (int i = 0; i < baseProperties.Count; i++)
+                {
+                    var baseProperty = baseProperties[i];
+                    if (baseProperty == defaultProperty)
+                    {
+                        baseProperty = new FactoryTypePropertyDescriptor(defaultProperty);
+                    }
+
+                    properties[i] = baseProperty;
+                }
+
+                for (int i = 0; i < instanceProperties.Count; i++)
+                {
+                    var expandedProperty = instanceProperties[i];
+                    properties[i + baseProperties.Count] = expandedProperty;
+                }
+                return new PropertyDescriptorCollection(properties);
+            }
+
+            return baseProperties;
+        }
+
+        object ICustomTypeDescriptor.GetPropertyOwner(PropertyDescriptor pd)
+        {
+            return pd?.ComponentType.IsAssignableFrom(GetType()) == true ? this : Operator;
+        }
+
+        class FactoryTypePropertyDescriptor : PropertyDescriptor
+        {
+            readonly PropertyDescriptor descriptor;
+
+            public FactoryTypePropertyDescriptor(PropertyDescriptor descr)
+                : base(descr)
+            {
+                descriptor = descr;
+            }
+
+            public override Type ComponentType => descriptor.ComponentType;
+
+            public override bool IsReadOnly => false;
+
+            public override Type PropertyType => typeof(Type);
+
+            public override bool CanResetValue(object component)
+            {
+                return true;
+            }
+
+            public override object GetValue(object component)
+            {
+                component = descriptor.GetValue(component);
+                return component?.GetType();
+            }
+
+            public override void ResetValue(object component)
+            {
+                descriptor.SetValue(component, null);
+            }
+
+            public override void SetValue(object component, object value)
+            {
+                var currentValue = descriptor.GetValue(component);
+                var newValue = Activator.CreateInstance((Type)value);
+
+                var newProperties = TypeDescriptor.GetProperties(newValue);
+                var currentProperties = TypeDescriptor.GetProperties(currentValue);
+                foreach (PropertyDescriptor property in newProperties)
+                {
+                    var mergeProperty = currentProperties[property.Name];
+                    if (mergeProperty?.PropertyType == property.PropertyType)
+                    {
+                        var propertyValue = mergeProperty.GetValue(currentValue);
+                        property.SetValue(newValue, propertyValue);
+                    }
+                }
+
+                descriptor.SetValue(component, newValue);
+            }
+
+            public override bool ShouldSerializeValue(object component)
+            {
+                return true;
+            }
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
This PR introduces a polymorphic operator for dynamic configuration of individual channel parameters.

All 18 configuration parameters are combined into a single operator allowing selection of which parameter to manipulate in the property grid. Depending on the selected parameter, the name and type of the channel and property changes. It is also possible to externalize any of the variables for dynamic mapping scenarios.