### PR TITLE
Portname dropdown missing

### DIFF
--- a/Bonsai.PulsePal/PulsePal.cs
+++ b/Bonsai.PulsePal/PulsePal.cs
@@ -319,7 +319,7 @@ namespace Bonsai.PulsePal
         /// Sets a delay between the arrival of a trigger and when the channel
         /// begins its pulse train.
         /// </summary>
-        /// <param name="channel">The output channel to configure.</param>
+        /// <param name="channel">The output channel to configure.</50param>
         /// <param name="seconds">
         /// The delay to start the pulse train, in the range [0.0001, 3600] seconds.
         /// </param>
@@ -749,7 +749,7 @@ namespace Bonsai.PulsePal
 
             readonly int GetVoltageSteps(decimal volts)
             {
-                return (int)(decimal.Ceiling((volts + 10) / 20) * device.dacMaxValue);
+                return (int)(decimal.Ceiling(((volts + 10) / 20) * device.dacMaxValue));
             }
 
             readonly uint GetTimeCycles(decimal seconds)

--- a/Bonsai.PulsePal/TriggerOutput.cs
+++ b/Bonsai.PulsePal/TriggerOutput.cs
@@ -9,7 +9,7 @@ namespace Bonsai.PulsePal
     public class TriggerOutput : Sink
     {
         [Description("The name of the serial port.")]
-        [Editor("Bonsai.PulsePal.Design.PulsePalConfigurationEditor, Bonsai.PulsePal.Design", typeof(UITypeEditor))]
+        [TypeConverter(typeof(PortNameConverter))]
         public string PortName { get; set; }
 
         [Description("A value representing the bitmask of channels to trigger.")]

--- a/Bonsai.PulsePal/UpdatePulseTrain.cs
+++ b/Bonsai.PulsePal/UpdatePulseTrain.cs
@@ -15,7 +15,7 @@ namespace Bonsai.PulsePal
         }
 
         [Description("The name of the serial port.")]
-        [Editor("Bonsai.PulsePal.Design.PulsePalConfigurationEditor, Bonsai.PulsePal.Design", typeof(UITypeEditor))]
+        [TypeConverter(typeof(PortNameConverter))]
         public string PortName { get; set; }
 
         [Description("The identifier of the custom pulse train.")]


### PR DESCRIPTION
PortName dropdown was missing in nodes UpdatePulseTrain and TriggerOutput.
Apply [TypeConverter(typeof(PortNameConverter))] to property Portname.