### PR TITLE
Add netstandard target for cross-platform support

### DIFF
--- a/Bonsai.PulsePal/Bonsai.PulsePal.csproj
+++ b/Bonsai.PulsePal/Bonsai.PulsePal.csproj
@@ -4,7 +4,7 @@
     <Title>Bonsai - PulsePal Library</Title>
     <Description>Bonsai Library containing modules for interfacing with the PulsePal pulse train generator.</Description>
     <PackageTags>Bonsai Rx PulsePal Pulse Stimulator</PackageTags>
-    <TargetFramework>net462</TargetFramework>
+    <TargetFrameworks>net462;netstandard2.0</TargetFrameworks>
     <LangVersion>9.0</LangVersion>
     <Version>0.2.0</Version>
   </PropertyGroup>

--- a/Bonsai.PulsePal/TriggerOutput.cs
+++ b/Bonsai.PulsePal/TriggerOutput.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.ComponentModel;
-using System.Drawing.Design;
 using System.Reactive.Linq;
 
 namespace Bonsai.PulsePal
@@ -8,8 +7,8 @@ namespace Bonsai.PulsePal
     [Description("Triggers the specified output channels to begin playing their pulse sequences.")]
     public class TriggerOutput : Sink
     {
-        [Description("The name of the serial port.")]
-        [Editor("Bonsai.PulsePal.Design.PulsePalConfigurationEditor, Bonsai.PulsePal.Design", typeof(UITypeEditor))]
+        [TypeConverter(typeof(PortNameConverter))]
+        [Description("The name of the serial port used to communicate with the Pulse Pal device.")]
         public string PortName { get; set; }
 
         [Description("A value representing the bitmask of channels to trigger.")]

--- a/Bonsai.PulsePal/UpdatePulseTrain.cs
+++ b/Bonsai.PulsePal/UpdatePulseTrain.cs
@@ -1,7 +1,6 @@
 ﻿using OpenCV.Net;
 using System;
 using System.ComponentModel;
-using System.Drawing.Design;
 using System.Reactive.Linq;
 
 namespace Bonsai.PulsePal
@@ -14,8 +13,8 @@ namespace Bonsai.PulsePal
             PulseId = 1;
         }
 
-        [Description("The name of the serial port.")]
-        [Editor("Bonsai.PulsePal.Design.PulsePalConfigurationEditor, Bonsai.PulsePal.Design", typeof(UITypeEditor))]
+        [TypeConverter(typeof(PortNameConverter))]
+        [Description("The name of the serial port used to communicate with the Pulse Pal device.")]
         public string PortName { get; set; }
 
         [Description("The identifier of the custom pulse train.")]


### PR DESCRIPTION
This PR introduces a new platform target for `netstandard2.0` to improve cross-platform compatibility for present and future releases. In principle this would allow running pure PulsePal workflows on Linux and MacOS platforms through the command-line interface.