### PR TITLE
Add missing descriptions and dynamic naming of channel configuration operator

### DIFF
--- a/Bonsai.PulsePal/Configuration/BiphasicConfiguration.cs
+++ b/Bonsai.PulsePal/Configuration/BiphasicConfiguration.cs
@@ -7,6 +7,7 @@ namespace Bonsai.PulsePal
     /// will produce either monophasic or biphasic square pulses.
     /// </summary>
     [DisplayName(nameof(ParameterCode.Biphasic))]
+    [Description("Specifies whether the channel will generate monophasic or biphasic square pulses.")]
     public class BiphasicConfiguration : OutputChannelParameterConfiguration
     {
         /// <summary>

--- a/Bonsai.PulsePal/Configuration/BurstDurationConfiguration.cs
+++ b/Bonsai.PulsePal/Configuration/BurstDurationConfiguration.cs
@@ -7,6 +7,7 @@ namespace Bonsai.PulsePal
     /// burst when using burst mode.
     /// </summary>
     [DisplayName(nameof(ParameterCode.BurstDuration))]
+    [Description("Specifies the duration of a pulse burst when using burst mode.")]
     public class BurstDurationConfiguration : OutputChannelParameterConfiguration
     {
         /// <summary>

--- a/Bonsai.PulsePal/Configuration/CustomTrainIdentityConfiguration.cs
+++ b/Bonsai.PulsePal/Configuration/CustomTrainIdentityConfiguration.cs
@@ -7,6 +7,7 @@ namespace Bonsai.PulsePal
     /// train used to specify pulse times and voltages on an output channel.
     /// </summary>
     [DisplayName(nameof(ParameterCode.CustomTrainIdentity))]
+    [Description("Specifies the identity of the custom train to use on the output channel.")]
     public class CustomTrainIdentityConfiguration : OutputChannelParameterConfiguration
     {
         /// <summary>

--- a/Bonsai.PulsePal/Configuration/CustomTrainLoopConfiguration.cs
+++ b/Bonsai.PulsePal/Configuration/CustomTrainLoopConfiguration.cs
@@ -7,6 +7,7 @@ namespace Bonsai.PulsePal
     /// will loop its custom pulse train.
     /// </summary>
     [DisplayName(nameof(ParameterCode.CustomTrainLoop))]
+    [Description("Specifies whether the output channel will loop its custom pulse train.")]
     public class CustomTrainLoopConfiguration : OutputChannelParameterConfiguration
     {
         /// <summary>

--- a/Bonsai.PulsePal/Configuration/CustomTrainTargetConfiguration.cs
+++ b/Bonsai.PulsePal/Configuration/CustomTrainTargetConfiguration.cs
@@ -7,6 +7,7 @@ namespace Bonsai.PulsePal
     /// in the custom train configured on this output channel.
     /// </summary>
     [DisplayName(nameof(ParameterCode.CustomTrainTarget))]
+    [Description("Specifies the interpretation of pulse times in the channel custom pulse train.")]
     public class CustomTrainTargetConfiguration : OutputChannelParameterConfiguration
     {
         /// <summary>

--- a/Bonsai.PulsePal/Configuration/InterBurstIntervalConfiguration.cs
+++ b/Bonsai.PulsePal/Configuration/InterBurstIntervalConfiguration.cs
@@ -7,6 +7,7 @@ namespace Bonsai.PulsePal
     /// off-time between bursts.
     /// </summary>
     [DisplayName(nameof(ParameterCode.InterBurstInterval))]
+    [Description("Specifies the duration of the off-time between bursts.")]
     public class InterBurstIntervalConfiguration : OutputChannelParameterConfiguration
     {
         /// <summary>

--- a/Bonsai.PulsePal/Configuration/InterPhaseIntervalConfiguration.cs
+++ b/Bonsai.PulsePal/Configuration/InterPhaseIntervalConfiguration.cs
@@ -7,6 +7,7 @@ namespace Bonsai.PulsePal
     /// and second phases of biphasic pulses.
     /// </summary>
     [DisplayName(nameof(ParameterCode.InterPhaseInterval))]
+    [Description("Specifies the interval between the first and second phases of biphasic pulses.")]
     public class InterPhaseIntervalConfiguration : OutputChannelParameterConfiguration
     {
         /// <summary>

--- a/Bonsai.PulsePal/Configuration/InterPulseIntervalConfiguration.cs
+++ b/Bonsai.PulsePal/Configuration/InterPulseIntervalConfiguration.cs
@@ -6,6 +6,7 @@ namespace Bonsai.PulsePal
     /// Represents configuration parameters specifying the interval between pulses.
     /// </summary>
     [DisplayName(nameof(ParameterCode.InterPulseInterval))]
+    [Description("Specifies the interval between pulses.")]
     public class InterPulseIntervalConfiguration : OutputChannelParameterConfiguration
     {
         /// <summary>

--- a/Bonsai.PulsePal/Configuration/Phase1DurationConfiguration.cs
+++ b/Bonsai.PulsePal/Configuration/Phase1DurationConfiguration.cs
@@ -7,6 +7,7 @@ namespace Bonsai.PulsePal
     /// phase of each pulse.
     /// </summary>
     [DisplayName(nameof(ParameterCode.Phase1Duration))]
+    [Description("Specifies the duration for the first phase of each pulse.")]
     public class Phase1DurationConfiguration : OutputChannelParameterConfiguration
     {
         /// <summary>

--- a/Bonsai.PulsePal/Configuration/Phase1VoltageConfiguration.cs
+++ b/Bonsai.PulsePal/Configuration/Phase1VoltageConfiguration.cs
@@ -7,6 +7,7 @@ namespace Bonsai.PulsePal
     /// phase of each pulse.
     /// </summary>
     [DisplayName(nameof(ParameterCode.Phase1Voltage))]
+    [Description("Specifies the voltage for the first phase of each pulse.")]
     public class Phase1VoltageConfiguration : OutputChannelParameterConfiguration
     {
         /// <summary>

--- a/Bonsai.PulsePal/Configuration/Phase2DurationConfiguration.cs
+++ b/Bonsai.PulsePal/Configuration/Phase2DurationConfiguration.cs
@@ -7,6 +7,7 @@ namespace Bonsai.PulsePal
     /// phase of each pulse.
     /// </summary>
     [DisplayName(nameof(ParameterCode.Phase2Duration))]
+    [Description("Specifies the duration for the second phase of each pulse.")]
     public class Phase2DurationConfiguration : OutputChannelParameterConfiguration
     {
         /// <summary>

--- a/Bonsai.PulsePal/Configuration/Phase2VoltageConfiguration.cs
+++ b/Bonsai.PulsePal/Configuration/Phase2VoltageConfiguration.cs
@@ -7,6 +7,7 @@ namespace Bonsai.PulsePal
     /// phase of each pulse.
     /// </summary>
     [DisplayName(nameof(ParameterCode.Phase2Voltage))]
+    [Description("Specifies the voltage for the second phase of each pulse.")]
     public class Phase2VoltageConfiguration : OutputChannelParameterConfiguration
     {
         /// <summary>

--- a/Bonsai.PulsePal/Configuration/PulseTrainDelayConfiguration.cs
+++ b/Bonsai.PulsePal/Configuration/PulseTrainDelayConfiguration.cs
@@ -3,10 +3,11 @@
 namespace Bonsai.PulsePal
 {
     /// <summary>
-    /// Represents configuration parameters specifying a delay between the arrival of
+    /// Represents configuration parameters specifying the delay between the arrival of
     /// a trigger and when the channel begins its pulse train.
     /// </summary>
     [DisplayName(nameof(ParameterCode.PulseTrainDelay))]
+    [Description("Specifies the delay between the arrival of a trigger and when the channel begins its pulse train.")]
     public class PulseTrainDelayConfiguration : OutputChannelParameterConfiguration
     {
         /// <summary>

--- a/Bonsai.PulsePal/Configuration/PulseTrainDurationConfiguration.cs
+++ b/Bonsai.PulsePal/Configuration/PulseTrainDurationConfiguration.cs
@@ -7,6 +7,7 @@ namespace Bonsai.PulsePal
     /// entire pulse train.
     /// </summary>
     [DisplayName(nameof(ParameterCode.PulseTrainDuration))]
+    [Description("Specifies the duration of the entire pulse train.")]
     public class PulseTrainDurationConfiguration : OutputChannelParameterConfiguration
     {
         /// <summary>

--- a/Bonsai.PulsePal/Configuration/RestingVoltageConfiguration.cs
+++ b/Bonsai.PulsePal/Configuration/RestingVoltageConfiguration.cs
@@ -7,6 +7,7 @@ namespace Bonsai.PulsePal
     /// output channel, i.e. the voltage between phases, pulses and pulse trains.
     /// </summary>
     [DisplayName(nameof(ParameterCode.RestingVoltage))]
+    [Description("Specifies the resting voltage on this output channel.")]
     public class RestingVoltageConfiguration : OutputChannelParameterConfiguration
     {
         /// <summary>

--- a/Bonsai.PulsePal/Configuration/TriggerModeConfiguration.cs
+++ b/Bonsai.PulsePal/Configuration/TriggerModeConfiguration.cs
@@ -6,6 +6,7 @@ namespace Bonsai.PulsePal
     /// Represents configuration parameters specifying the behavior of a trigger channel.
     /// </summary>
     [DisplayName(nameof(ParameterCode.TriggerMode))]
+    [Description("Specifies the behavior of a trigger channel.")]
     public class TriggerModeConfiguration : TriggerChannelParameterConfiguration
     {
         /// <summary>

--- a/Bonsai.PulsePal/Configuration/TriggerOnChannel1Configuration.cs
+++ b/Bonsai.PulsePal/Configuration/TriggerOnChannel1Configuration.cs
@@ -7,6 +7,7 @@ namespace Bonsai.PulsePal
     /// trigger the output channel.
     /// </summary>
     [DisplayName(nameof(ParameterCode.TriggerOnChannel1))]
+    [Description("Specifies whether trigger channel 1 can trigger the output channel.")]
     public class TriggerOnChannel1Configuration : OutputChannelParameterConfiguration
     {
         /// <summary>

--- a/Bonsai.PulsePal/Configuration/TriggerOnChannel2Configuration.cs
+++ b/Bonsai.PulsePal/Configuration/TriggerOnChannel2Configuration.cs
@@ -7,6 +7,7 @@ namespace Bonsai.PulsePal
     /// trigger the output channel.
     /// </summary>
     [DisplayName(nameof(ParameterCode.TriggerOnChannel2))]
+    [Description("Specifies whether trigger channel 2 can trigger the output channel.")]
     public class TriggerOnChannel2Configuration : OutputChannelParameterConfiguration
     {
         /// <summary>

--- a/Bonsai.PulsePal/ConfigureChannelParameter.cs
+++ b/Bonsai.PulsePal/ConfigureChannelParameter.cs
@@ -2,6 +2,7 @@
 using System.ComponentModel;
 using System.Reactive.Linq;
 using System.Xml.Serialization;
+using Bonsai.Expressions;
 
 namespace Bonsai.PulsePal
 {
@@ -30,7 +31,7 @@ namespace Bonsai.PulsePal
     [XmlInclude(typeof(TriggerModeConfiguration))]
     [WorkflowElementCategory(ElementCategory.Sink)]
     [Description("Configures a single channel parameter on a Pulse Pal device.")]
-    public class ConfigureChannelParameter : PolymorphicCombinator
+    public class ConfigureChannelParameter : PolymorphicCombinator, INamedElement
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ConfigureChannelParameter"/> class.
@@ -39,6 +40,8 @@ namespace Bonsai.PulsePal
         {
             Parameter = new BiphasicConfiguration();
         }
+
+        string INamedElement.Name => $"Set{ExpressionBuilder.GetElementDisplayName(Parameter)}";
 
         /// <summary>
         /// Gets or sets the name of the serial port used to communicate with the


### PR DESCRIPTION
This PR adds missing description attributes to each of the configuration classes used by the `ConfigureChannelParameter` polymorphic operator. To increase readability of workflows setting the various parameters, the PR also implements `INamedElement` in such a way that the name of the operator will follow the name of the selected parameter to configure.