### PR TITLE
Add continuous loop mode configuration

### DIFF
--- a/Bonsai.PulsePal/Configuration/ContinuousLoopConfiguration.cs
+++ b/Bonsai.PulsePal/Configuration/ContinuousLoopConfiguration.cs
@@ -1,0 +1,26 @@
+﻿using System.ComponentModel;
+
+namespace Bonsai.PulsePal
+{
+    /// <summary>
+    /// Represents configuration parameters specifying whether to play this output channel
+    /// pulse train indefinitely when triggered, without needing to be re-triggered.
+    /// </summary>
+    [DisplayName(nameof(ContinuousLoop))]
+    [Description("Specifies whether to play the output channel pulse train indefinitely when triggered, without needing to be re-triggered.")]
+    public class ContinuousLoopConfiguration : OutputChannelParameterConfiguration
+    {
+        /// <summary>
+        /// Gets or sets a value specifying whether to set the output channel in
+        /// continuous loop mode.
+        /// </summary>
+        [Description("Specifies whether to set the output channel in continuous loop mode.")]
+        public bool ContinuousLoop { get; set; }
+
+        /// <inheritdoc/>
+        public override void Configure(PulsePal device)
+        {
+            device.SetContinuousLoop(Channel, ContinuousLoop);
+        }
+    }
+}

--- a/Bonsai.PulsePal/ConfigureChannelParameter.cs
+++ b/Bonsai.PulsePal/ConfigureChannelParameter.cs
@@ -29,6 +29,7 @@ namespace Bonsai.PulsePal
     [XmlInclude(typeof(CustomTrainLoopConfiguration))]
     [XmlInclude(typeof(RestingVoltageConfiguration))]
     [XmlInclude(typeof(TriggerModeConfiguration))]
+    [XmlInclude(typeof(ContinuousLoopConfiguration))]
     [WorkflowElementCategory(ElementCategory.Sink)]
     [Description("Configures a single channel parameter on a Pulse Pal device.")]
     public class ConfigureChannelParameter : PolymorphicCombinator, INamedElement

--- a/Bonsai.PulsePal/ConfigureOutputChannel.cs
+++ b/Bonsai.PulsePal/ConfigureOutputChannel.cs
@@ -210,6 +210,14 @@ namespace Bonsai.PulsePal
         public bool TriggerOnChannel2 { get; set; }
 
         /// <summary>
+        /// Gets or sets a value specifying whether to set the output channel in
+        /// continuous loop mode.
+        /// </summary>
+        [Category(TriggerCategory)]
+        [Description("Specifies whether to set the output channel in continuous loop mode.")]
+        public bool ContinuousLoop { get; set; }
+
+        /// <summary>
         /// Configures the output channel parameters on the Pulse Pal device whenever
         /// an observable sequence emits a notification.
         /// </summary>
@@ -276,6 +284,7 @@ namespace Bonsai.PulsePal
             pulsePal.SetCustomTrainTarget(channel, CustomTrainTarget);
             pulsePal.SetCustomTrainLoop(channel, CustomTrainLoop);
             pulsePal.SetRestingVoltage(channel, RestingVoltage);
+            pulsePal.SetContinuousLoop(channel, ContinuousLoop);
         }
 
         /// <inheritdoc/>


### PR DESCRIPTION
This PR allows configuring continuous loop mode as a polymorphic channel parameter. Even though continuous loop is not strictly part of the channel parameter set, following the considerations in #25 makes it easier to find this option.