### PR TITLE
Add operator for setting fixed voltage

### DIFF
--- a/Bonsai.PulsePal/SetFixedVoltage.cs
+++ b/Bonsai.PulsePal/SetFixedVoltage.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.ComponentModel;
+using System.Reactive.Linq;
+
+namespace Bonsai.PulsePal
+{
+    /// <summary>
+    /// Represents an operator that sets a constant voltage on an output channel.
+    /// </summary>
+    [Description("Sets a constant voltage on an output channel.")]
+    public class SetFixedVoltage : Sink
+    {
+        const double MinVoltage = OutputChannelParameterConfiguration.MinVoltage;
+        const double MaxVoltage = OutputChannelParameterConfiguration.MaxVoltage;
+        const int VoltageDecimalPlaces = OutputChannelParameterConfiguration.VoltageDecimalPlaces;
+        const double VoltageIncrement = OutputChannelParameterConfiguration.VoltageIncrement;
+
+        /// <summary>
+        /// Gets or sets the name of the serial port used to communicate with the
+        /// Pulse Pal device.
+        /// </summary>
+        [TypeConverter(typeof(PortNameConverter))]
+        [Description("The name of the serial port used to communicate with the Pulse Pal device.")]
+        public string PortName { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value specifying the output channel to set to a fixed voltage.
+        /// </summary>
+        [Description("Specifies the output channel to set to a fixed voltage.")]
+        public OutputChannel Channel { get; set; } = OutputChannel.Channel1;
+
+        /// <summary>
+        /// Gets or sets the constant voltage for the output channel.
+        /// </summary>
+        [Range(MinVoltage, MaxVoltage)]
+        [Precision(VoltageDecimalPlaces, VoltageIncrement)]
+        [Editor(DesignTypes.SliderEditor, DesignTypes.UITypeEditor)]
+        [Description("The constant voltage for the output channel.")]
+        public double Voltage { get; set; }
+
+        /// <summary>
+        /// Sets a constant voltage on an output channel in the Pulse Pal device whenever
+        /// an observable sequence emits a notification.
+        /// </summary>
+        /// <typeparam name="TSource">
+        /// The type of the elements in the <paramref name="source"/> sequence.
+        /// </typeparam>
+        /// <param name="source">
+        /// The sequence containing the notifications used to set the fixed voltage
+        /// on the specified Pulse Pal channel.
+        /// </param>
+        /// <returns>
+        /// An observable sequence that is identical to the <paramref name="source"/>
+        /// sequence but where there is an additional side effect of setting a single
+        /// channel on the Pulse Pal device to a constant voltage whenever the sequence
+        /// emits a notification.
+        /// </returns>
+        public override IObservable<TSource> Process<TSource>(IObservable<TSource> source)
+        {
+            return Observable.Using(
+                () => PulsePalManager.ReserveConnection(PortName),
+                connection => source.Do(input =>
+                {
+                    lock (connection.PulsePal)
+                    {
+                        connection.PulsePal.SetFixedVoltage(Channel, Voltage);
+                    }
+                }));
+        }
+    }
+}


### PR DESCRIPTION
This PR adds support for setting a Pulse Pal output channel to a specified constant fixed voltage level. This function is kept as a separate operator under the assumption it overrides existing pulse trains already in operation.

Fixes #25 