### PR TITLE
Add support for updating the oLED display

### DIFF
--- a/Bonsai.PulsePal/UpdateDisplay.cs
+++ b/Bonsai.PulsePal/UpdateDisplay.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.ComponentModel;
+using System.Reactive.Linq;
+
+namespace Bonsai.PulsePal
+{
+    /// <summary>
+    /// Represents an operator that writes a sequence of text strings to the
+    /// Pulse Pal oLED display.
+    /// </summary>
+    [Description("Writes a sequence of text strings to the Pulse Pal oLED display.")]
+    public class UpdateDisplay : Sink<string>
+    {
+        /// <summary>
+        /// Gets or sets the name of the serial port used to communicate with the
+        /// Pulse Pal device.
+        /// </summary>
+        [TypeConverter(typeof(PortNameConverter))]
+        [Description("The name of the serial port used to communicate with the Pulse Pal device.")]
+        public string PortName { get; set; }
+
+        /// <summary>
+        /// Writes an observable sequence of text strings to the Pulse Pal oLED display.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence where each value represents a text string to display on the top
+        /// row of the oLED display. Text must be less than 17 characters in length.
+        /// </param>
+        /// <returns>
+        /// An observable sequence that is identical to the <paramref name="source"/>
+        /// sequence but where there is an additional side effect of writing each text
+        /// string to the Pulse Pal oLED display.
+        /// </returns>
+        public override IObservable<string> Process(IObservable<string> source)
+        {
+            return Observable.Using(
+                () => PulsePalManager.ReserveConnection(PortName),
+                connection => source.Do(value =>
+                {
+                    lock (connection.PulsePal)
+                    {
+                        connection.PulsePal.UpdateDisplay(value);
+                    }
+                }));
+        }
+
+        /// <summary>
+        /// Writes an observable sequence of text strings to the Pulse Pal oLED display.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence where each value represents a pair of text strings to display
+        /// respectively on the top and bottom rows of the oLED display. The text in
+        /// each row must be less than 17 characters in length.
+        /// </param>
+        /// <returns>
+        /// An observable sequence that is identical to the <paramref name="source"/>
+        /// sequence but where there is an additional side effect of writing each pair
+        /// of text strings to the top and bottom rows of the Pulse Pal oLED display.
+        /// </returns>
+        public IObservable<Tuple<string, string>> Process(IObservable<Tuple<string, string>> source)
+        {
+            return Observable.Using(
+                () => PulsePalManager.ReserveConnection(PortName),
+                connection => source.Do(value =>
+                {
+                    lock (connection.PulsePal)
+                    {
+                        connection.PulsePal.UpdateDisplay(value.Item1, value.Item2);
+                    }
+                }));
+        }
+    }
+}


### PR DESCRIPTION
This PR introduces a new operator `UpdateDisplay` for updating the text strings in the top and bottom rows of the Pulse Pal oLED display. The standard Pulse Pal menu will also overwrite the display, so this function is useful mostly during fully automated operation of the device. 