### PR TITLE
Workaround to handle faulty bootstrapper exit code

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,6 +29,7 @@ jobs:
 
       - name: Setup Bonsai
         working-directory: .bonsai
+        continue-on-error: true
         run: .\Setup.ps1
 
       - name: Build Documentation


### PR DESCRIPTION
This PR introduces a temporary workaround for issue https://github.com/bonsai-rx/bonsai/issues/1687 which causes the bootstrapper to return an error exit code even on successful environment recovery.