### PR TITLE
Fix pulsepal protocol transmission and max cycle period

### DIFF
--- a/src/Bonsai.PulsePal/Bonsai.PulsePal.csproj
+++ b/src/Bonsai.PulsePal/Bonsai.PulsePal.csproj
@@ -6,7 +6,7 @@
     <PackageTags>Bonsai Rx PulsePal Pulse Stimulator</PackageTags>
     <TargetFrameworks>net462;netstandard2.0</TargetFrameworks>
     <VersionPrefix>0.2.0</VersionPrefix>
-    <VersionSuffix>preview2</VersionSuffix>
+    <VersionSuffix>preview3</VersionSuffix>
     <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 

--- a/src/Bonsai.PulsePal/PulsePal.cs
+++ b/src/Bonsai.PulsePal/PulsePal.cs
@@ -16,7 +16,7 @@ namespace Bonsai.PulsePal
         internal const double MinTimePeriod = 0.0001;
         internal const double MaxTimePeriod = 3600;
 
-        const int BaudRate = 115200;
+        const int BaudRate = 12000000;
         const int CycleFrequency = 20000;
         const int MaxCyclePeriod = 36000000;
         const int MaxPulseLength = 1000;

--- a/src/Bonsai.PulsePal/PulsePal.cs
+++ b/src/Bonsai.PulsePal/PulsePal.cs
@@ -18,7 +18,7 @@ namespace Bonsai.PulsePal
 
         const int BaudRate = 12000000;
         const int CycleFrequency = 20000;
-        const int MaxCyclePeriod = 36000000;
+        const int MaxCyclePeriod = 3600 * CycleFrequency;
         const int MaxPulseLength = 1000;
         const int MaxDataBytes = 8192;
 


### PR DESCRIPTION
This PR updates the `PulsePal` device class to connect at full speed and adjust max cycle period to match cycle frequency.

Fixes #37 
Fixes #38 