### PR TITLE
Fix bootstrapper templates for automatic SVG export

### DIFF
--- a/.bonsai/Bonsai.config
+++ b/.bonsai/Bonsai.config
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageConfiguration xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Packages>
-    <Package id="Bonsai" version="2.8.1" />
+    <Package id="Bonsai" version="2.8.2" />
     <Package id="Bonsai.Core" version="2.8.1" />
     <Package id="Bonsai.Design" version="2.8.0" />
-    <Package id="Bonsai.Editor" version="2.8.0" />
+    <Package id="Bonsai.Editor" version="2.8.1" />
     <Package id="jacobslusser.ScintillaNET" version="3.6.3" />
     <Package id="Markdig" version="0.18.1" />
     <Package id="Microsoft.Web.WebView2" version="1.0.1823.32" />
@@ -22,10 +22,10 @@
     <AssemblyReference assemblyName="Bonsai.Editor" />
   </AssemblyReferences>
   <AssemblyLocations>
-    <AssemblyLocation assemblyName="Bonsai" processorArchitecture="MSIL" location="Packages\Bonsai.2.8.1\lib\net48\Bonsai.exe" />
+    <AssemblyLocation assemblyName="Bonsai" processorArchitecture="MSIL" location="Packages\Bonsai.2.8.2\lib\net48\Bonsai.exe" />
     <AssemblyLocation assemblyName="Bonsai.Core" processorArchitecture="MSIL" location="Packages\Bonsai.Core.2.8.1\lib\net462\Bonsai.Core.dll" />
     <AssemblyLocation assemblyName="Bonsai.Design" processorArchitecture="MSIL" location="Packages\Bonsai.Design.2.8.0\lib\net462\Bonsai.Design.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Editor" processorArchitecture="MSIL" location="Packages\Bonsai.Editor.2.8.0\lib\net472\Bonsai.Editor.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Editor" processorArchitecture="MSIL" location="Packages\Bonsai.Editor.2.8.1\lib\net472\Bonsai.Editor.dll" />
     <AssemblyLocation assemblyName="Markdig" processorArchitecture="MSIL" location="Packages\Markdig.0.18.1\lib\net40\Markdig.dll" />
     <AssemblyLocation assemblyName="Microsoft.Web.WebView2.Core" processorArchitecture="MSIL" location="Packages\Microsoft.Web.WebView2.1.0.1823.32\lib\net45\Microsoft.Web.WebView2.Core.dll" />
     <AssemblyLocation assemblyName="Microsoft.Web.WebView2.WinForms" processorArchitecture="MSIL" location="Packages\Microsoft.Web.WebView2.1.0.1823.32\lib\net45\Microsoft.Web.WebView2.WinForms.dll" />

--- a/.bonsai/Setup.cmd
+++ b/.bonsai/Setup.cmd
@@ -1,1 +1,4 @@
+@echo off
+pushd %~dp0
 powershell -ExecutionPolicy Bypass -File ./Setup.ps1
+popd

--- a/.bonsai/Setup.ps1
+++ b/.bonsai/Setup.ps1
@@ -1,3 +1,4 @@
+Push-Location $PSScriptRoot
 if (!(Test-Path "./Bonsai.exe")) {
     $release = "https://github.com/bonsai-rx/bonsai/releases/latest/download/Bonsai.zip"
     $configPath = "./Bonsai.config"
@@ -10,10 +11,11 @@ if (!(Test-Path "./Bonsai.exe")) {
         }
     }
     Invoke-WebRequest $release -OutFile "temp.zip"
-    Move-Item -Path "NuGet.config" "temp.config"
+    Move-Item -Path "NuGet.config" "temp.config" -ErrorAction SilentlyContinue
     Expand-Archive "temp.zip" -DestinationPath "." -Force
-    Move-Item -Path "temp.config" "NuGet.config" -Force
+    Move-Item -Path "temp.config" "NuGet.config" -Force -ErrorAction SilentlyContinue
     Remove-Item -Path "temp.zip"
-	Remove-Item -Path "Bonsai32.exe"
+    Remove-Item -Path "Bonsai32.exe"
 }
 & .\Bonsai.exe --no-editor
+Pop-Location

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,17 +12,14 @@ jobs:
     runs-on: windows-latest
  
     steps:
-    - name: Checkout
-      uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v4.1.1
 
-    - name: Setup MSBuild
-      uses: microsoft/setup-msbuild@v1
-       
-    - name: Setup NuGet
-      uses: NuGet/setup-nuget@v1.2.0
-     
-    - name: Restore NuGet Packages
-      run: nuget restore src/Bonsai.PulsePal.sln
- 
-    - name: Build Solution
-      run: msbuild src/Bonsai.PulsePal.sln /p:Configuration=Release
+      - name: Setup MSBuild
+        uses: microsoft/setup-msbuild@v2
+        
+      - name: Restore NuGet Packages
+        run: msbuild -t:restore src/Bonsai.PulsePal.sln
+  
+      - name: Build Solution
+        run: msbuild src/Bonsai.PulsePal.sln /p:Configuration=Release

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,28 +8,30 @@ jobs:
   build:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v2
-        name: Checkout
+      - name: Checkout
+        uses: actions/checkout@v4.1.1
         with:
           submodules: true
 
-      - name: Setup .NET Core SDK
-        uses: actions/setup-dotnet@v3.2.0
-        with:
-          dotnet-version: 7.x
-
       - name: Setup MSBuild
-        uses: microsoft/setup-msbuild@v1
-      
+        uses: microsoft/setup-msbuild@v2
+        
       - name: Restore NuGet Packages
         run: msbuild -t:restore src/Bonsai.PulsePal.sln
+  
+      - name: Build Solution
+        run: msbuild src/Bonsai.PulsePal.sln /p:Configuration=Release
+    
+      - name: Setup .NET Core SDK
+        uses: actions/setup-dotnet@v4.0.0
+        with:
+          dotnet-version: 7.x
 
       - name: Setup DocFX
         run: dotnet tool restore
 
       - name: Setup Bonsai
         working-directory: .bonsai
-        continue-on-error: true
         run: .\Setup.ps1
 
       - name: Build Documentation
@@ -37,12 +39,12 @@ jobs:
         run: .\build.ps1
           
       - name: Checkout gh-pages
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4.1.1
         with:
           ref: gh-pages
           path: gh-pages
       - name: Publish to github pages
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v3.9.3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: docs/_site

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ bin
 obj
 *.user
 *.exe
+*.exe.old
 *.exe.settings
 
 # bonsai environment

--- a/docs/articles/intro.md
+++ b/docs/articles/intro.md
@@ -1,3 +1,7 @@
 # Introduction
 
 [!include[Overview](~/articles/overview.md)]
+
+:::workflow
+![CreatePulsePal](../workflows/create-pulsepal.bonsai)
+:::

--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -60,7 +60,7 @@
       "_enableNewTab": true,
       "_enableSearch": true,
       "pdf": false,
-      "_appFooter": "<span>&copy; 2024 Bonsai Foundation and Contributors</span> - <span>Made with <a href=\"https://dotnet.github.io/docfx\">docfx</a></span>",
+      "_appFooter": "&copy; 2024 Bonsai Foundation CIC and Contributors. Made with <a href=\"https://dotnet.github.io/docfx\">docfx</a>",
       "_gitContribute": {
         "repo": "https://github.com/bonsai-rx/pulsepal",
         "branch": "main",

--- a/docs/workflows/create-pulsepal.bonsai
+++ b/docs/workflows/create-pulsepal.bonsai
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<WorkflowBuilder Version="2.8.1"
+                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xmlns:pal="clr-namespace:Bonsai.PulsePal;assembly=Bonsai.PulsePal"
+                 xmlns="https://bonsai-rx.org/2018/workflow">
+  <Workflow>
+    <Nodes>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="pal:CreatePulsePal">
+          <pal:OutputChannels />
+          <pal:TriggerChannels />
+        </Combinator>
+      </Expression>
+    </Nodes>
+    <Edges />
+  </Workflow>
+</WorkflowBuilder>


### PR DESCRIPTION
This PR updates the bootstrapper templates to fix relative path access and allow exporting SVG images for example workflows automatically. An example workflow is included as a test.