### PR TITLE
Rename port name properties to device name

### DIFF
--- a/src/Bonsai.PulsePal/Configuration/BiphasicConfiguration.cs
+++ b/src/Bonsai.PulsePal/Configuration/BiphasicConfiguration.cs
@@ -18,7 +18,7 @@ namespace Bonsai.PulsePal
         public bool Biphasic { get; set; }
 
         /// <inheritdoc/>
-        public override void Configure(PulsePal device)
+        public override void Configure(PulsePalDevice device)
         {
             device.SetBiphasic(Channel, Biphasic);
         }

--- a/src/Bonsai.PulsePal/Configuration/BurstDurationConfiguration.cs
+++ b/src/Bonsai.PulsePal/Configuration/BurstDurationConfiguration.cs
@@ -21,7 +21,7 @@ namespace Bonsai.PulsePal
         public double BurstDuration { get; set; } = MinTimePeriod;
 
         /// <inheritdoc/>
-        public override void Configure(PulsePal device)
+        public override void Configure(PulsePalDevice device)
         {
             device.SetBurstDuration(Channel, BurstDuration);
         }

--- a/src/Bonsai.PulsePal/Configuration/ChannelParameterConfiguration.cs
+++ b/src/Bonsai.PulsePal/Configuration/ChannelParameterConfiguration.cs
@@ -11,6 +11,6 @@
         /// Pulse Pal device.
         /// </summary>
         /// <param name="device">The Pulse Pal device to configure.</param>
-        public abstract void Configure(PulsePal device);
+        public abstract void Configure(PulsePalDevice device);
     }
 }

--- a/src/Bonsai.PulsePal/Configuration/ContinuousLoopConfiguration.cs
+++ b/src/Bonsai.PulsePal/Configuration/ContinuousLoopConfiguration.cs
@@ -18,7 +18,7 @@ namespace Bonsai.PulsePal
         public bool ContinuousLoop { get; set; }
 
         /// <inheritdoc/>
-        public override void Configure(PulsePal device)
+        public override void Configure(PulsePalDevice device)
         {
             device.SetContinuousLoop(Channel, ContinuousLoop);
         }

--- a/src/Bonsai.PulsePal/Configuration/CustomTrainIdentityConfiguration.cs
+++ b/src/Bonsai.PulsePal/Configuration/CustomTrainIdentityConfiguration.cs
@@ -18,7 +18,7 @@ namespace Bonsai.PulsePal
         public CustomTrainId CustomTrainIdentity { get; set; }
 
         /// <inheritdoc/>
-        public override void Configure(PulsePal device)
+        public override void Configure(PulsePalDevice device)
         {
             device.SetCustomTrainIdentity(Channel, CustomTrainIdentity);
         }

--- a/src/Bonsai.PulsePal/Configuration/CustomTrainLoopConfiguration.cs
+++ b/src/Bonsai.PulsePal/Configuration/CustomTrainLoopConfiguration.cs
@@ -18,7 +18,7 @@ namespace Bonsai.PulsePal
         public bool CustomTrainLoop { get; set; }
 
         /// <inheritdoc/>
-        public override void Configure(PulsePal device)
+        public override void Configure(PulsePalDevice device)
         {
             device.SetCustomTrainLoop(Channel, CustomTrainLoop);
         }

--- a/src/Bonsai.PulsePal/Configuration/CustomTrainTargetConfiguration.cs
+++ b/src/Bonsai.PulsePal/Configuration/CustomTrainTargetConfiguration.cs
@@ -18,7 +18,7 @@ namespace Bonsai.PulsePal
         public CustomTrainTarget CustomTrainTarget { get; set; }
 
         /// <inheritdoc/>
-        public override void Configure(PulsePal device)
+        public override void Configure(PulsePalDevice device)
         {
             device.SetCustomTrainTarget(Channel, CustomTrainTarget);
         }

--- a/src/Bonsai.PulsePal/Configuration/InterBurstIntervalConfiguration.cs
+++ b/src/Bonsai.PulsePal/Configuration/InterBurstIntervalConfiguration.cs
@@ -21,7 +21,7 @@ namespace Bonsai.PulsePal
         public double InterBurstInterval { get; set; } = MinTimePeriod;
 
         /// <inheritdoc/>
-        public override void Configure(PulsePal device)
+        public override void Configure(PulsePalDevice device)
         {
             device.SetInterBurstInterval(Channel, InterBurstInterval);
         }

--- a/src/Bonsai.PulsePal/Configuration/InterPhaseIntervalConfiguration.cs
+++ b/src/Bonsai.PulsePal/Configuration/InterPhaseIntervalConfiguration.cs
@@ -21,7 +21,7 @@ namespace Bonsai.PulsePal
         public double InterPhaseInterval { get; set; } = MinTimePeriod;
 
         /// <inheritdoc/>
-        public override void Configure(PulsePal device)
+        public override void Configure(PulsePalDevice device)
         {
             device.SetInterPhaseInterval(Channel, InterPhaseInterval);
         }

--- a/src/Bonsai.PulsePal/Configuration/InterPulseIntervalConfiguration.cs
+++ b/src/Bonsai.PulsePal/Configuration/InterPulseIntervalConfiguration.cs
@@ -19,7 +19,7 @@ namespace Bonsai.PulsePal
         public double InterPulseInterval { get; set; } = MinTimePeriod;
 
         /// <inheritdoc/>
-        public override void Configure(PulsePal device)
+        public override void Configure(PulsePalDevice device)
         {
             device.SetInterPulseInterval(Channel, InterPulseInterval);
         }

--- a/src/Bonsai.PulsePal/Configuration/OutputChannelParameterConfiguration.cs
+++ b/src/Bonsai.PulsePal/Configuration/OutputChannelParameterConfiguration.cs
@@ -8,10 +8,10 @@ namespace Bonsai.PulsePal
     /// </summary>
     public abstract class OutputChannelParameterConfiguration : ChannelParameterConfiguration
     {
-        internal const double MinVoltage = PulsePal.MinVoltage;
-        internal const double MaxVoltage = PulsePal.MaxVoltage;
-        internal const double MinTimePeriod = PulsePal.MinTimePeriod;
-        internal const double MaxTimePeriod = PulsePal.MaxTimePeriod;
+        internal const double MinVoltage = PulsePalDevice.MinVoltage;
+        internal const double MaxVoltage = PulsePalDevice.MaxVoltage;
+        internal const double MinTimePeriod = PulsePalDevice.MinTimePeriod;
+        internal const double MaxTimePeriod = PulsePalDevice.MaxTimePeriod;
         internal const int VoltageDecimalPlaces = 3;
         internal const double VoltageIncrement = 0.001;
         internal const int TimeDecimalPlaces = 4;

--- a/src/Bonsai.PulsePal/Configuration/Phase1DurationConfiguration.cs
+++ b/src/Bonsai.PulsePal/Configuration/Phase1DurationConfiguration.cs
@@ -21,7 +21,7 @@ namespace Bonsai.PulsePal
         public double Phase1Duration { get; set; } = MinTimePeriod;
 
         /// <inheritdoc/>
-        public override void Configure(PulsePal device)
+        public override void Configure(PulsePalDevice device)
         {
             device.SetPhase1Duration(Channel, Phase1Duration);
         }

--- a/src/Bonsai.PulsePal/Configuration/Phase1VoltageConfiguration.cs
+++ b/src/Bonsai.PulsePal/Configuration/Phase1VoltageConfiguration.cs
@@ -20,7 +20,7 @@ namespace Bonsai.PulsePal
         public double Phase1Voltage { get; set; }
 
         /// <inheritdoc/>
-        public override void Configure(PulsePal device)
+        public override void Configure(PulsePalDevice device)
         {
             device.SetPhase1Voltage(Channel, Phase1Voltage);
         }

--- a/src/Bonsai.PulsePal/Configuration/Phase2DurationConfiguration.cs
+++ b/src/Bonsai.PulsePal/Configuration/Phase2DurationConfiguration.cs
@@ -21,7 +21,7 @@ namespace Bonsai.PulsePal
         public double Phase2Duration { get; set; } = MinTimePeriod;
 
         /// <inheritdoc/>
-        public override void Configure(PulsePal device)
+        public override void Configure(PulsePalDevice device)
         {
             device.SetPhase2Duration(Channel, Phase2Duration);
         }

--- a/src/Bonsai.PulsePal/Configuration/Phase2VoltageConfiguration.cs
+++ b/src/Bonsai.PulsePal/Configuration/Phase2VoltageConfiguration.cs
@@ -20,7 +20,7 @@ namespace Bonsai.PulsePal
         public double Phase2Voltage { get; set; }
 
         /// <inheritdoc/>
-        public override void Configure(PulsePal device)
+        public override void Configure(PulsePalDevice device)
         {
             device.SetPhase2Voltage(Channel, Phase2Voltage);
         }

--- a/src/Bonsai.PulsePal/Configuration/PulseTrainDelayConfiguration.cs
+++ b/src/Bonsai.PulsePal/Configuration/PulseTrainDelayConfiguration.cs
@@ -21,7 +21,7 @@ namespace Bonsai.PulsePal
         public double PulseTrainDelay { get; set; } = MinTimePeriod;
 
         /// <inheritdoc/>
-        public override void Configure(PulsePal device)
+        public override void Configure(PulsePalDevice device)
         {
             device.SetPulseTrainDelay(Channel, PulseTrainDelay);
         }

--- a/src/Bonsai.PulsePal/Configuration/PulseTrainDurationConfiguration.cs
+++ b/src/Bonsai.PulsePal/Configuration/PulseTrainDurationConfiguration.cs
@@ -21,7 +21,7 @@ namespace Bonsai.PulsePal
         public double PulseTrainDuration { get; set; } = MinTimePeriod;
 
         /// <inheritdoc/>
-        public override void Configure(PulsePal device)
+        public override void Configure(PulsePalDevice device)
         {
             device.SetPulseTrainDuration(Channel, PulseTrainDuration);
         }

--- a/src/Bonsai.PulsePal/Configuration/RestingVoltageConfiguration.cs
+++ b/src/Bonsai.PulsePal/Configuration/RestingVoltageConfiguration.cs
@@ -20,7 +20,7 @@ namespace Bonsai.PulsePal
         public double RestingVoltage { get; set; }
 
         /// <inheritdoc/>
-        public override void Configure(PulsePal device)
+        public override void Configure(PulsePalDevice device)
         {
             device.SetRestingVoltage(Channel, RestingVoltage);
         }

--- a/src/Bonsai.PulsePal/Configuration/TriggerModeConfiguration.cs
+++ b/src/Bonsai.PulsePal/Configuration/TriggerModeConfiguration.cs
@@ -16,7 +16,7 @@ namespace Bonsai.PulsePal
         public TriggerMode TriggerMode { get; set; }
 
         /// <inheritdoc/>
-        public override void Configure(PulsePal device)
+        public override void Configure(PulsePalDevice device)
         {
             device.SetTriggerMode(Channel, TriggerMode);
         }

--- a/src/Bonsai.PulsePal/Configuration/TriggerOnChannel1Configuration.cs
+++ b/src/Bonsai.PulsePal/Configuration/TriggerOnChannel1Configuration.cs
@@ -18,7 +18,7 @@ namespace Bonsai.PulsePal
         public bool TriggerOnChannel1 { get; set; }
 
         /// <inheritdoc/>
-        public override void Configure(PulsePal device)
+        public override void Configure(PulsePalDevice device)
         {
             device.SetTriggerOnChannel1(Channel, TriggerOnChannel1);
         }

--- a/src/Bonsai.PulsePal/Configuration/TriggerOnChannel2Configuration.cs
+++ b/src/Bonsai.PulsePal/Configuration/TriggerOnChannel2Configuration.cs
@@ -18,7 +18,7 @@ namespace Bonsai.PulsePal
         public bool TriggerOnChannel2 { get; set; }
 
         /// <inheritdoc/>
-        public override void Configure(PulsePal device)
+        public override void Configure(PulsePalDevice device)
         {
             device.SetTriggerOnChannel2(Channel, TriggerOnChannel2);
         }

--- a/src/Bonsai.PulsePal/ConfigureChannelParameter.cs
+++ b/src/Bonsai.PulsePal/ConfigureChannelParameter.cs
@@ -109,7 +109,7 @@ namespace Bonsai.PulsePal
         /// sequence but where there is an additional side effect of configuring a
         /// single channel parameter on each Pulse Pal device.
         /// </returns>
-        public IObservable<PulsePal> Process(IObservable<PulsePal> source)
+        public IObservable<PulsePalDevice> Process(IObservable<PulsePalDevice> source)
         {
             return source.Do(Parameter.Configure);
         }

--- a/src/Bonsai.PulsePal/ConfigureChannelParameter.cs
+++ b/src/Bonsai.PulsePal/ConfigureChannelParameter.cs
@@ -45,12 +45,11 @@ namespace Bonsai.PulsePal
         string INamedElement.Name => $"Set{ExpressionBuilder.GetElementDisplayName(Parameter)}";
 
         /// <summary>
-        /// Gets or sets the name of the serial port used to communicate with the
-        /// Pulse Pal device.
+        /// Gets or sets the name of the Pulse Pal device.
         /// </summary>
-        [TypeConverter(typeof(PortNameConverter))]
-        [Description("The name of the serial port used to communicate with the Pulse Pal device.")]
-        public string PortName { get; set; }
+        [TypeConverter(typeof(DeviceNameConverter))]
+        [Description("The name of the Pulse Pal device.")]
+        public string DeviceName { get; set; }
 
         /// <summary>
         /// Gets or sets the channel parameter to configure.
@@ -87,7 +86,7 @@ namespace Bonsai.PulsePal
         public IObservable<TSource> Process<TSource>(IObservable<TSource> source)
         {
             return Observable.Using(
-                () => PulsePalManager.ReserveConnection(PortName),
+                () => PulsePalManager.ReserveConnection(DeviceName),
                 connection => source.Do(input =>
                 {
                     lock (connection.PulsePal)

--- a/src/Bonsai.PulsePal/ConfigureChannelParameter.cs
+++ b/src/Bonsai.PulsePal/ConfigureChannelParameter.cs
@@ -49,7 +49,7 @@ namespace Bonsai.PulsePal
         /// </summary>
         [TypeConverter(typeof(DeviceNameConverter))]
         [Description("The name of the Pulse Pal device.")]
-        public string DeviceName { get; set; }
+        public string DeviceName { get; set; } = nameof(PulsePal);
 
         /// <summary>
         /// Gets or sets the channel parameter to configure.

--- a/src/Bonsai.PulsePal/ConfigureOutputChannel.cs
+++ b/src/Bonsai.PulsePal/ConfigureOutputChannel.cs
@@ -34,7 +34,7 @@ namespace Bonsai.PulsePal
         [Category(ChannelCategory)]
         [TypeConverter(typeof(DeviceNameConverter))]
         [Description("The name of the Pulse Pal device.")]
-        public string DeviceName { get; set; }
+        public string DeviceName { get; set; } = nameof(PulsePal);
 
         /// <summary>
         /// Gets or sets the output channel to configure.

--- a/src/Bonsai.PulsePal/ConfigureOutputChannel.cs
+++ b/src/Bonsai.PulsePal/ConfigureOutputChannel.cs
@@ -16,10 +16,10 @@ namespace Bonsai.PulsePal
         const string TimingCategory = "Pulse Timing";
         const string CustomTrainCategory = "Custom Train";
         const string TriggerCategory = "Pulse Trigger";
-        const double MinVoltage = PulsePal.MinVoltage;
-        const double MaxVoltage = PulsePal.MaxVoltage;
-        const double MinTimePeriod = PulsePal.MinTimePeriod;
-        const double MaxTimePeriod = PulsePal.MaxTimePeriod;
+        const double MinVoltage = PulsePalDevice.MinVoltage;
+        const double MaxVoltage = PulsePalDevice.MaxVoltage;
+        const double MinTimePeriod = PulsePalDevice.MinTimePeriod;
+        const double MaxTimePeriod = PulsePalDevice.MaxTimePeriod;
         const int VoltageDecimalPlaces = OutputChannelParameterConfiguration.VoltageDecimalPlaces;
         const double VoltageIncrement = OutputChannelParameterConfiguration.VoltageIncrement;
         const int TimeDecimalPlaces = OutputChannelParameterConfiguration.TimeDecimalPlaces;
@@ -259,12 +259,12 @@ namespace Bonsai.PulsePal
         /// sequence but where there is an additional side effect of configuring the
         /// output channel parameters on each Pulse Pal device.
         /// </returns>
-        public IObservable<PulsePal> Process(IObservable<PulsePal> source)
+        public IObservable<PulsePalDevice> Process(IObservable<PulsePalDevice> source)
         {
             return source.Do(Configure);
         }
 
-        internal void Configure(PulsePal pulsePal)
+        internal void Configure(PulsePalDevice pulsePal)
         {
             var channel = Channel;
             pulsePal.SetBiphasic(channel, Biphasic);

--- a/src/Bonsai.PulsePal/ConfigureOutputChannel.cs
+++ b/src/Bonsai.PulsePal/ConfigureOutputChannel.cs
@@ -29,13 +29,12 @@ namespace Bonsai.PulsePal
             : $"ConfigureOutput{Channel}";
 
         /// <summary>
-        /// Gets or sets the name of the serial port used to communicate with the
-        /// Pulse Pal device.
+        /// Gets or sets the name of the Pulse Pal device.
         /// </summary>
         [Category(ChannelCategory)]
-        [TypeConverter(typeof(PortNameConverter))]
-        [Description("The name of the serial port used to communicate with the Pulse Pal device.")]
-        public string PortName { get; set; }
+        [TypeConverter(typeof(DeviceNameConverter))]
+        [Description("The name of the Pulse Pal device.")]
+        public string DeviceName { get; set; }
 
         /// <summary>
         /// Gets or sets the output channel to configure.
@@ -237,7 +236,7 @@ namespace Bonsai.PulsePal
         public override IObservable<TSource> Process<TSource>(IObservable<TSource> source)
         {
             return Observable.Using(
-                () => PulsePalManager.ReserveConnection(PortName),
+                () => PulsePalManager.ReserveConnection(DeviceName),
                 connection => source.Do(input =>
                 {
                     lock (connection.PulsePal)

--- a/src/Bonsai.PulsePal/ConfigureTriggerChannel.cs
+++ b/src/Bonsai.PulsePal/ConfigureTriggerChannel.cs
@@ -81,12 +81,12 @@ namespace Bonsai.PulsePal
         /// sequence but where there is an additional side effect of configuring the
         /// trigger channel parameters on each Pulse Pal device.
         /// </returns>
-        public IObservable<PulsePal> Process(IObservable<PulsePal> source)
+        public IObservable<PulsePalDevice> Process(IObservable<PulsePalDevice> source)
         {
             return source.Do(Configure);
         }
 
-        internal void Configure(PulsePal pulsePal)
+        internal void Configure(PulsePalDevice pulsePal)
         {
             var channel = Channel;
             pulsePal.SetTriggerMode(channel, TriggerMode);

--- a/src/Bonsai.PulsePal/ConfigureTriggerChannel.cs
+++ b/src/Bonsai.PulsePal/ConfigureTriggerChannel.cs
@@ -22,7 +22,7 @@ namespace Bonsai.PulsePal
         [Category(ChannelCategory)]
         [TypeConverter(typeof(DeviceNameConverter))]
         [Description("The name of the Pulse Pal device.")]
-        public string DeviceName { get; set; }
+        public string DeviceName { get; set; } = nameof(PulsePal);
 
         /// <summary>
         /// Gets or sets the output channel to configure.

--- a/src/Bonsai.PulsePal/ConfigureTriggerChannel.cs
+++ b/src/Bonsai.PulsePal/ConfigureTriggerChannel.cs
@@ -17,13 +17,12 @@ namespace Bonsai.PulsePal
             : $"ConfigureTrigger{Channel}";
 
         /// <summary>
-        /// Gets or sets the name of the serial port used to communicate with the
-        /// Pulse Pal device.
+        /// Gets or sets the name of the Pulse Pal device.
         /// </summary>
         [Category(ChannelCategory)]
-        [TypeConverter(typeof(PortNameConverter))]
-        [Description("The name of the serial port used to communicate with the Pulse Pal device.")]
-        public string PortName { get; set; }
+        [TypeConverter(typeof(DeviceNameConverter))]
+        [Description("The name of the Pulse Pal device.")]
+        public string DeviceName { get; set; }
 
         /// <summary>
         /// Gets or sets the output channel to configure.
@@ -59,7 +58,7 @@ namespace Bonsai.PulsePal
         public override IObservable<TSource> Process<TSource>(IObservable<TSource> source)
         {
             return Observable.Using(
-                () => PulsePalManager.ReserveConnection(PortName),
+                () => PulsePalManager.ReserveConnection(DeviceName),
                 connection => source.Do(input =>
                 {
                     lock (connection.PulsePal)

--- a/src/Bonsai.PulsePal/CreatePulsePal.cs
+++ b/src/Bonsai.PulsePal/CreatePulsePal.cs
@@ -12,7 +12,7 @@ namespace Bonsai.PulsePal
     /// </summary>
     [DefaultProperty(nameof(OutputChannels))]
     [Description("Creates and configures a serial connection to a Pulse Pal device.")]
-    public class CreatePulsePal : Source<PulsePal>, INamedElement
+    public class CreatePulsePal : Source<PulsePalDevice>, INamedElement
     {
         const string ChannelCategory = "Channel";
 
@@ -54,10 +54,10 @@ namespace Bonsai.PulsePal
         /// Generates an observable sequence that contains the serial interface object.
         /// </summary>
         /// <returns>
-        /// A sequence containing a single instance of the <see cref="PulsePal"/> class
+        /// A sequence containing a single instance of the <see cref="PulsePalDevice"/> class
         /// representing the serial interface to Pulse Pal.
         /// </returns>
-        public override IObservable<PulsePal> Generate()
+        public override IObservable<PulsePalDevice> Generate()
         {
             return Observable.Using(
                 () => PulsePalManager.ReserveConnection(Name, configuration),

--- a/src/Bonsai.PulsePal/CreatePulsePal.cs
+++ b/src/Bonsai.PulsePal/CreatePulsePal.cs
@@ -12,17 +12,17 @@ namespace Bonsai.PulsePal
     /// </summary>
     [DefaultProperty(nameof(OutputChannels))]
     [Description("Creates and configures a serial connection to a Pulse Pal device.")]
-    public class CreatePulsePal : Source<PulsePalDevice>, INamedElement
+    public class CreatePulsePal : Source<PulsePalDevice>
     {
         const string ChannelCategory = "Channel";
 
         readonly PulsePalConfiguration configuration = new();
 
         /// <summary>
-        /// Gets or sets the optional alias for the Pulse Pal device.
+        /// Gets or sets the name of the Pulse Pal device.
         /// </summary>
-        [Description("The optional alias for the Pulse Pal device.")]
-        public string Name { get; set; }
+        [Description("The name of the Pulse Pal device.")]
+        public string DeviceName { get; set; } = nameof(PulsePal);
 
         /// <summary>
         /// Gets or sets the name of the serial port used to communicate
@@ -60,7 +60,7 @@ namespace Bonsai.PulsePal
         public override IObservable<PulsePalDevice> Generate()
         {
             return Observable.Using(
-                () => PulsePalManager.ReserveConnection(Name, configuration),
+                () => PulsePalManager.ReserveConnection(DeviceName, configuration),
                 resource => Observable.Return(resource.PulsePal)
                                       .Concat(Observable.Never(resource.PulsePal)));
         }

--- a/src/Bonsai.PulsePal/DeviceNameConverter.cs
+++ b/src/Bonsai.PulsePal/DeviceNameConverter.cs
@@ -5,7 +5,7 @@ using Bonsai.Expressions;
 
 namespace Bonsai.PulsePal
 {
-    class PortNameConverter : StringConverter
+    class DeviceNameConverter : StringConverter
     {
         public override bool GetStandardValuesSupported(ITypeDescriptorContext context)
         {
@@ -21,9 +21,9 @@ namespace Bonsai.PulsePal
                 {
                     var portNames = (from builder in workflowBuilder.Workflow.Descendants()
                                      where builder is not DisableBuilder
-                                     let createPort = ExpressionBuilder.GetWorkflowElement(builder) as CreatePulsePal
-                                     where createPort != null && !string.IsNullOrEmpty(createPort.PortName)
-                                     select !string.IsNullOrEmpty(createPort.Name) ? createPort.Name : createPort.PortName)
+                                     let createPulsePal = ExpressionBuilder.GetWorkflowElement(builder) as CreatePulsePal
+                                     where createPulsePal != null && !string.IsNullOrEmpty(createPulsePal.PortName)
+                                     select !string.IsNullOrEmpty(createPulsePal.DeviceName) ? createPulsePal.DeviceName : createPulsePal.PortName)
                                      .Distinct()
                                      .ToList();
                     if (portNames.Count > 0)

--- a/src/Bonsai.PulsePal/PulseOnset.cs
+++ b/src/Bonsai.PulsePal/PulseOnset.cs
@@ -14,10 +14,10 @@ namespace Bonsai.PulsePal
     [Description("Creates a sequence of custom pulse train onset times and voltages.")]
     public class PulseOnset : Combinator<PulseOnset>
     {
-        const double MinVoltage = PulsePal.MinVoltage;
-        const double MaxVoltage = PulsePal.MaxVoltage;
-        const double MinTimePeriod = PulsePal.MinTimePeriod;
-        const double MaxTimePeriod = PulsePal.MaxTimePeriod;
+        const double MinVoltage = PulsePalDevice.MinVoltage;
+        const double MaxVoltage = PulsePalDevice.MaxVoltage;
+        const double MinTimePeriod = PulsePalDevice.MinTimePeriod;
+        const double MaxTimePeriod = PulsePalDevice.MaxTimePeriod;
         const int VoltageDecimalPlaces = OutputChannelParameterConfiguration.VoltageDecimalPlaces;
         const double VoltageIncrement = OutputChannelParameterConfiguration.VoltageIncrement;
         const int TimeDecimalPlaces = OutputChannelParameterConfiguration.TimeDecimalPlaces;

--- a/src/Bonsai.PulsePal/PulsePalConfiguration.cs
+++ b/src/Bonsai.PulsePal/PulsePalConfiguration.cs
@@ -10,7 +10,7 @@
 
         public ConfigureTriggerChannelCollection TriggerChannels { get; } = new();
 
-        public void Configure(PulsePal pulsePal)
+        public void Configure(PulsePalDevice pulsePal)
         {
             foreach (var outputChannel in OutputChannels)
             {

--- a/src/Bonsai.PulsePal/PulsePalDevice.cs
+++ b/src/Bonsai.PulsePal/PulsePalDevice.cs
@@ -9,7 +9,7 @@ namespace Bonsai.PulsePal
     /// <summary>
     /// Represents a Pulse Pal device.
     /// </summary>
-    public sealed class PulsePal : IDisposable
+    public sealed class PulsePalDevice : IDisposable
     {
         internal const double MinVoltage = -10;
         internal const double MaxVoltage = 10;
@@ -47,13 +47,13 @@ namespace Bonsai.PulsePal
         readonly byte[] readBuffer;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="PulsePal"/> class using
+        /// Initializes a new instance of the <see cref="PulsePalDevice"/> class using
         /// the specified port name.
         /// </summary>
         /// <param name="portName">
         /// The name of the serial port used to communicate with the Pulse Pal device.
         /// </param>
-        public PulsePal(string portName)
+        public PulsePalDevice(string portName)
         {
             serialPort = new SerialPort(portName);
             serialPort.BaudRate = BaudRate;
@@ -79,7 +79,7 @@ namespace Bonsai.PulsePal
         }
 
         /// <summary>
-        /// Gets a value indicating the open or closed status of the <see cref="PulsePal"/> object.
+        /// Gets a value indicating the open or closed status of the <see cref="PulsePalDevice"/> object.
         /// </summary>
         public bool IsOpen
         {
@@ -818,9 +818,9 @@ namespace Bonsai.PulsePal
         {
             int offset;
             double previousTime;
-            readonly PulsePal device;
+            readonly PulsePalDevice device;
 
-            public CommandWriter(PulsePal pulsePal)
+            public CommandWriter(PulsePalDevice pulsePal)
             {
                 offset = 0;
                 previousTime = -MinTimePeriod;

--- a/src/Bonsai.PulsePal/PulsePalDisposable.cs
+++ b/src/Bonsai.PulsePal/PulsePalDisposable.cs
@@ -8,13 +8,13 @@ namespace Bonsai.PulsePal
     {
         IDisposable resource;
 
-        public PulsePalDisposable(PulsePal pulsePal, IDisposable disposable)
+        public PulsePalDisposable(PulsePalDevice pulsePal, IDisposable disposable)
         {
             PulsePal = pulsePal ?? throw new ArgumentNullException(nameof(pulsePal));
             resource = disposable ?? throw new ArgumentNullException(nameof(disposable));
         }
 
-        public PulsePal PulsePal { get; private set; }
+        public PulsePalDevice PulsePal { get; private set; }
 
         public bool IsDisposed => resource == null;
 

--- a/src/Bonsai.PulsePal/PulsePalManager.cs
+++ b/src/Bonsai.PulsePal/PulsePalManager.cs
@@ -7,7 +7,7 @@ namespace Bonsai.PulsePal
 {
     internal static class PulsePalManager
     {
-        static readonly Dictionary<string, Tuple<PulsePal, RefCountDisposable>> openConnections = new();
+        static readonly Dictionary<string, Tuple<PulsePalDevice, RefCountDisposable>> openConnections = new();
         static readonly object openConnectionsLock = new();
 
         internal static PulsePalDisposable ReserveConnection(string portName)
@@ -17,7 +17,7 @@ namespace Bonsai.PulsePal
 
         internal static PulsePalDisposable ReserveConnection(string portName, PulsePalConfiguration pulsePalConfiguration)
         {
-            var connection = default(Tuple<PulsePal, RefCountDisposable>);
+            var connection = default(Tuple<PulsePalDevice, RefCountDisposable>);
             lock (openConnectionsLock)
             {
                 if (string.IsNullOrEmpty(portName))
@@ -32,7 +32,7 @@ namespace Bonsai.PulsePal
                     var serialPortName = pulsePalConfiguration.PortName;
                     if (string.IsNullOrEmpty(serialPortName)) serialPortName = portName;
 
-                    var pulsePal = new PulsePal(serialPortName);
+                    var pulsePal = new PulsePalDevice(serialPortName);
                     try
                     {
                         pulsePal.Open();

--- a/src/Bonsai.PulsePal/SendCustomPulseTrain.cs
+++ b/src/Bonsai.PulsePal/SendCustomPulseTrain.cs
@@ -13,12 +13,11 @@ namespace Bonsai.PulsePal
     public class SendCustomPulseTrain : Sink<PulseOnset[]>
     {
         /// <summary>
-        /// Gets or sets the name of the serial port used to communicate with the
-        /// Pulse Pal device.
+        /// Gets or sets the name of the Pulse Pal device.
         /// </summary>
-        [TypeConverter(typeof(PortNameConverter))]
-        [Description("The name of the serial port used to communicate with the Pulse Pal device.")]
-        public string PortName { get; set; }
+        [TypeConverter(typeof(DeviceNameConverter))]
+        [Description("The name of the Pulse Pal device.")]
+        public string DeviceName { get; set; }
 
         /// <summary>
         /// Gets or sets the identity of the custom pulse train to program.
@@ -42,7 +41,7 @@ namespace Bonsai.PulsePal
         public override IObservable<PulseOnset[]> Process(IObservable<PulseOnset[]> source)
         {
             return Observable.Using(
-                () => PulsePalManager.ReserveConnection(PortName),
+                () => PulsePalManager.ReserveConnection(DeviceName),
                 pulsePal => source.Do(input =>
                 {
                     lock (pulsePal.PulsePal)
@@ -71,7 +70,7 @@ namespace Bonsai.PulsePal
         public IObservable<double[,]> Process(IObservable<double[,]> source)
         {
             return Observable.Using(
-                () => PulsePalManager.ReserveConnection(PortName),
+                () => PulsePalManager.ReserveConnection(DeviceName),
                 pulsePal => source.Do(input =>
                 {
                     lock (pulsePal.PulsePal)
@@ -99,7 +98,7 @@ namespace Bonsai.PulsePal
         public IObservable<Mat> Process(IObservable<Mat> source)
         {
             return Observable.Using(
-                () => PulsePalManager.ReserveConnection(PortName),
+                () => PulsePalManager.ReserveConnection(DeviceName),
                 pulsePal => source.Do(input =>
                 {
                     var pulseTrain = new double[2, input.Cols];

--- a/src/Bonsai.PulsePal/SendCustomPulseTrain.cs
+++ b/src/Bonsai.PulsePal/SendCustomPulseTrain.cs
@@ -17,7 +17,7 @@ namespace Bonsai.PulsePal
         /// </summary>
         [TypeConverter(typeof(DeviceNameConverter))]
         [Description("The name of the Pulse Pal device.")]
-        public string DeviceName { get; set; }
+        public string DeviceName { get; set; } = nameof(PulsePal);
 
         /// <summary>
         /// Gets or sets the identity of the custom pulse train to program.

--- a/src/Bonsai.PulsePal/SendCustomWaveform.cs
+++ b/src/Bonsai.PulsePal/SendCustomWaveform.cs
@@ -13,8 +13,8 @@ namespace Bonsai.PulsePal
     [Description("Uploads each array of voltages in a sequence to the Pulse Pal device, with periodic onset times.")]
     public class SendCustomWaveform : Sink<Mat>
     {
-        const double MinTimePeriod = PulsePal.MinTimePeriod;
-        const double MaxTimePeriod = PulsePal.MaxTimePeriod;
+        const double MinTimePeriod = PulsePalDevice.MinTimePeriod;
+        const double MaxTimePeriod = PulsePalDevice.MaxTimePeriod;
         const int TimeDecimalPlaces = OutputChannelParameterConfiguration.TimeDecimalPlaces;
 
         /// <summary>

--- a/src/Bonsai.PulsePal/SendCustomWaveform.cs
+++ b/src/Bonsai.PulsePal/SendCustomWaveform.cs
@@ -22,7 +22,7 @@ namespace Bonsai.PulsePal
         /// </summary>
         [TypeConverter(typeof(DeviceNameConverter))]
         [Description("The name of the Pulse Pal device.")]
-        public string DeviceName { get; set; }
+        public string DeviceName { get; set; } = nameof(PulsePal);
 
         /// <summary>
         /// Gets or sets the identity of the custom pulse train to program.

--- a/src/Bonsai.PulsePal/SendCustomWaveform.cs
+++ b/src/Bonsai.PulsePal/SendCustomWaveform.cs
@@ -18,12 +18,11 @@ namespace Bonsai.PulsePal
         const int TimeDecimalPlaces = OutputChannelParameterConfiguration.TimeDecimalPlaces;
 
         /// <summary>
-        /// Gets or sets the name of the serial port used to communicate with the
-        /// Pulse Pal device.
+        /// Gets or sets the name of the Pulse Pal device.
         /// </summary>
-        [TypeConverter(typeof(PortNameConverter))]
-        [Description("The name of the serial port used to communicate with the Pulse Pal device.")]
-        public string PortName { get; set; }
+        [TypeConverter(typeof(DeviceNameConverter))]
+        [Description("The name of the Pulse Pal device.")]
+        public string DeviceName { get; set; }
 
         /// <summary>
         /// Gets or sets the identity of the custom pulse train to program.
@@ -58,7 +57,7 @@ namespace Bonsai.PulsePal
         public IObservable<double[]> Process(IObservable<double[]> source)
         {
             return Observable.Using(
-                () => PulsePalManager.ReserveConnection(PortName),
+                () => PulsePalManager.ReserveConnection(DeviceName),
                 pulsePal => source.Do(pulseVoltages =>
                 {
                     lock (pulsePal.PulsePal)
@@ -86,7 +85,7 @@ namespace Bonsai.PulsePal
         public override IObservable<Mat> Process(IObservable<Mat> source)
         {
             return Observable.Using(
-                () => PulsePalManager.ReserveConnection(PortName),
+                () => PulsePalManager.ReserveConnection(DeviceName),
                 pulsePal => source.Do(input =>
                 {
                     var pulseVoltages = new double[input.Cols];

--- a/src/Bonsai.PulsePal/SetFixedVoltage.cs
+++ b/src/Bonsai.PulsePal/SetFixedVoltage.cs
@@ -16,12 +16,11 @@ namespace Bonsai.PulsePal
         const double VoltageIncrement = OutputChannelParameterConfiguration.VoltageIncrement;
 
         /// <summary>
-        /// Gets or sets the name of the serial port used to communicate with the
-        /// Pulse Pal device.
+        /// Gets or sets the name of the Pulse Pal device.
         /// </summary>
-        [TypeConverter(typeof(PortNameConverter))]
-        [Description("The name of the serial port used to communicate with the Pulse Pal device.")]
-        public string PortName { get; set; }
+        [TypeConverter(typeof(DeviceNameConverter))]
+        [Description("The name of the Pulse Pal device.")]
+        public string DeviceName { get; set; }
 
         /// <summary>
         /// Gets or sets a value specifying the output channel to set to a fixed voltage.
@@ -58,7 +57,7 @@ namespace Bonsai.PulsePal
         public override IObservable<TSource> Process<TSource>(IObservable<TSource> source)
         {
             return Observable.Using(
-                () => PulsePalManager.ReserveConnection(PortName),
+                () => PulsePalManager.ReserveConnection(DeviceName),
                 connection => source.Do(input =>
                 {
                     lock (connection.PulsePal)

--- a/src/Bonsai.PulsePal/SetFixedVoltage.cs
+++ b/src/Bonsai.PulsePal/SetFixedVoltage.cs
@@ -10,8 +10,8 @@ namespace Bonsai.PulsePal
     [Description("Sets a constant voltage on an output channel.")]
     public class SetFixedVoltage : Sink
     {
-        const double MinVoltage = PulsePal.MinVoltage;
-        const double MaxVoltage = PulsePal.MaxVoltage;
+        const double MinVoltage = PulsePalDevice.MinVoltage;
+        const double MaxVoltage = PulsePalDevice.MaxVoltage;
         const int VoltageDecimalPlaces = OutputChannelParameterConfiguration.VoltageDecimalPlaces;
         const double VoltageIncrement = OutputChannelParameterConfiguration.VoltageIncrement;
 

--- a/src/Bonsai.PulsePal/SetFixedVoltage.cs
+++ b/src/Bonsai.PulsePal/SetFixedVoltage.cs
@@ -20,7 +20,7 @@ namespace Bonsai.PulsePal
         /// </summary>
         [TypeConverter(typeof(DeviceNameConverter))]
         [Description("The name of the Pulse Pal device.")]
-        public string DeviceName { get; set; }
+        public string DeviceName { get; set; } = nameof(PulsePal);
 
         /// <summary>
         /// Gets or sets a value specifying the output channel to set to a fixed voltage.

--- a/src/Bonsai.PulsePal/TriggerOutputChannels.cs
+++ b/src/Bonsai.PulsePal/TriggerOutputChannels.cs
@@ -16,7 +16,7 @@ namespace Bonsai.PulsePal
         /// </summary>
         [TypeConverter(typeof(DeviceNameConverter))]
         [Description("The name of the Pulse Pal device.")]
-        public string DeviceName { get; set; }
+        public string DeviceName { get; set; } = nameof(PulsePal);
 
         /// <summary>
         /// Gets or sets a value specifying which output channel triggers to set.

--- a/src/Bonsai.PulsePal/TriggerOutputChannels.cs
+++ b/src/Bonsai.PulsePal/TriggerOutputChannels.cs
@@ -12,12 +12,11 @@ namespace Bonsai.PulsePal
     public class TriggerOutputChannels : Sink
     {
         /// <summary>
-        /// Gets or sets the name of the serial port used to communicate with the
-        /// Pulse Pal device.
+        /// Gets or sets the name of the Pulse Pal device.
         /// </summary>
-        [TypeConverter(typeof(PortNameConverter))]
-        [Description("The name of the serial port used to communicate with the Pulse Pal device.")]
-        public string PortName { get; set; }
+        [TypeConverter(typeof(DeviceNameConverter))]
+        [Description("The name of the Pulse Pal device.")]
+        public string DeviceName { get; set; }
 
         /// <summary>
         /// Gets or sets a value specifying which output channel triggers to set.
@@ -45,7 +44,7 @@ namespace Bonsai.PulsePal
         public override IObservable<TSource> Process<TSource>(IObservable<TSource> source)
         {
             return Observable.Using(
-                () => PulsePalManager.ReserveConnection(PortName),
+                () => PulsePalManager.ReserveConnection(DeviceName),
                 connection => source.Do(input =>
                 {
                     lock (connection.PulsePal)

--- a/src/Bonsai.PulsePal/UpdateDisplay.cs
+++ b/src/Bonsai.PulsePal/UpdateDisplay.cs
@@ -16,7 +16,7 @@ namespace Bonsai.PulsePal
         /// </summary>
         [TypeConverter(typeof(DeviceNameConverter))]
         [Description("The name of the Pulse Pal device.")]
-        public string DeviceName { get; set; }
+        public string DeviceName { get; set; } = nameof(PulsePal);
 
         /// <summary>
         /// Writes an observable sequence of text strings to the Pulse Pal oLED display.

--- a/src/Bonsai.PulsePal/UpdateDisplay.cs
+++ b/src/Bonsai.PulsePal/UpdateDisplay.cs
@@ -12,12 +12,11 @@ namespace Bonsai.PulsePal
     public class UpdateDisplay : Sink<string>
     {
         /// <summary>
-        /// Gets or sets the name of the serial port used to communicate with the
-        /// Pulse Pal device.
+        /// Gets or sets the name of the Pulse Pal device.
         /// </summary>
-        [TypeConverter(typeof(PortNameConverter))]
-        [Description("The name of the serial port used to communicate with the Pulse Pal device.")]
-        public string PortName { get; set; }
+        [TypeConverter(typeof(DeviceNameConverter))]
+        [Description("The name of the Pulse Pal device.")]
+        public string DeviceName { get; set; }
 
         /// <summary>
         /// Writes an observable sequence of text strings to the Pulse Pal oLED display.
@@ -34,7 +33,7 @@ namespace Bonsai.PulsePal
         public override IObservable<string> Process(IObservable<string> source)
         {
             return Observable.Using(
-                () => PulsePalManager.ReserveConnection(PortName),
+                () => PulsePalManager.ReserveConnection(DeviceName),
                 connection => source.Do(value =>
                 {
                     lock (connection.PulsePal)
@@ -60,7 +59,7 @@ namespace Bonsai.PulsePal
         public IObservable<Tuple<string, string>> Process(IObservable<Tuple<string, string>> source)
         {
             return Observable.Using(
-                () => PulsePalManager.ReserveConnection(PortName),
+                () => PulsePalManager.ReserveConnection(DeviceName),
                 connection => source.Do(value =>
                 {
                     lock (connection.PulsePal)


### PR DESCRIPTION
This PR refactors the general naming approach to the library to avoid name clashes, promote best practices and overall reduce confusion when using the library. Three main changes were introduced:
- Rename `PulsePal` to `PulsePalDevice` to avoid clashes with the `PulsePal` namespace ([CA1724](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1724))
- Rename `PortName` to `DeviceName` in all operators to indicate high-level device names should be used instead of port names. This is to avoid the error-prone practice of having to change port names throughout a workflow when changing the host machine configuration.
- Assign "PulsePal" as the default `DeviceName`.

Fixes #44 