### PR TITLE
Refactor configuration classes to avoid redundancy

### DIFF
--- a/src/Bonsai.PulsePal/Configuration/ChannelParameterConfiguration.cs
+++ b/src/Bonsai.PulsePal/Configuration/ChannelParameterConfiguration.cs
@@ -6,6 +6,8 @@
     /// </summary>
     public abstract class ChannelParameterConfiguration
     {
+        internal const string ChannelCategory = "Channel";
+
         /// <summary>
         /// Applies the channel parameter configuration to the specified
         /// Pulse Pal device.

--- a/src/Bonsai.PulsePal/Configuration/OutputChannelConfiguration.cs
+++ b/src/Bonsai.PulsePal/Configuration/OutputChannelConfiguration.cs
@@ -1,4 +1,5 @@
-﻿using System.ComponentModel;
+﻿using System;
+using System.ComponentModel;
 
 namespace Bonsai.PulsePal
 {
@@ -6,6 +7,7 @@ namespace Bonsai.PulsePal
     /// Represents pulse train configuration parameters for an output channel on a
     /// Pulse Pal device.
     /// </summary>
+    [TypeConverter(typeof(OutputChannelConfigurationConverter))]
     public class OutputChannelConfiguration : OutputChannelParameterConfiguration
     {
         const string VoltageCategory = "Pulse Voltage";
@@ -50,6 +52,17 @@ namespace Bonsai.PulsePal
         [Editor(DesignTypes.SliderEditor, DesignTypes.UITypeEditor)]
         [Description("The resting voltage.")]
         public double RestingVoltage { get; set; }
+
+        /// <summary>
+        /// Gets or sets the delay to start the pulse train, in the range
+        /// [0.0001, 3600] seconds.
+        /// </summary>
+        [Category(TimingCategory)]
+        [Range(MinTimePeriod, MaxTimePeriod)]
+        [Precision(TimeDecimalPlaces, MinTimePeriod)]
+        [Editor(DesignTypes.SliderEditor, DesignTypes.UITypeEditor)]
+        [Description("The delay to start the pulse train, in seconds.")]
+        public double PulseTrainDelay { get; set; } = MinTimePeriod;
 
         /// <summary>
         /// Gets or sets the duration of the first phase of the pulse, in the range
@@ -128,17 +141,6 @@ namespace Bonsai.PulsePal
         public double PulseTrainDuration { get; set; } = MinTimePeriod;
 
         /// <summary>
-        /// Gets or sets the delay to start the pulse train, in the range
-        /// [0.0001, 3600] seconds.
-        /// </summary>
-        [Category(TimingCategory)]
-        [Range(MinTimePeriod, MaxTimePeriod)]
-        [Precision(TimeDecimalPlaces, MinTimePeriod)]
-        [Editor(DesignTypes.SliderEditor, DesignTypes.UITypeEditor)]
-        [Description("The delay to start the pulse train, in seconds.")]
-        public double PulseTrainDelay { get; set; } = MinTimePeriod;
-
-        /// <summary>
         /// Gets or sets a value specifying the identity of the custom pulse train
         /// to use on this output channel.
         /// </summary>
@@ -193,6 +195,7 @@ namespace Bonsai.PulsePal
             pulsePal.SetBiphasic(channel, Biphasic);
             pulsePal.SetPhase1Voltage(channel, Phase1Voltage);
             pulsePal.SetPhase2Voltage(channel, Phase2Voltage);
+            pulsePal.SetPulseTrainDelay(channel, PulseTrainDelay);
             pulsePal.SetPhase1Duration(channel, Phase1Duration);
             pulsePal.SetInterPhaseInterval(channel, InterPhaseInterval);
             pulsePal.SetPhase2Duration(channel, Phase2Duration);
@@ -200,7 +203,6 @@ namespace Bonsai.PulsePal
             pulsePal.SetBurstDuration(channel, BurstDuration);
             pulsePal.SetInterBurstInterval(channel, InterBurstInterval);
             pulsePal.SetPulseTrainDuration(channel, PulseTrainDuration);
-            pulsePal.SetPulseTrainDelay(channel, PulseTrainDelay);
             pulsePal.SetTriggerOnChannel1(channel, TriggerOnChannel1);
             pulsePal.SetTriggerOnChannel2(channel, TriggerOnChannel2);
             pulsePal.SetCustomTrainIdentity(channel, CustomTrainIdentity);
@@ -214,6 +216,25 @@ namespace Bonsai.PulsePal
         public override string ToString()
         {
             return Channel == 0 ? nameof(OutputChannelConfiguration) : $"{Channel}";
+        }
+
+        class OutputChannelConfigurationConverter : ExpandableObjectConverter
+        {
+            public override PropertyDescriptorCollection GetProperties(ITypeDescriptorContext context, object value, Attribute[] attributes)
+            {
+                return base.GetProperties(context, value, attributes)
+                           .Sort(new[]
+                           {
+                               nameof(PulseTrainDelay),
+                               nameof(Phase1Duration),
+                               nameof(InterPhaseInterval),
+                               nameof(Phase2Duration),
+                               nameof(InterPulseInterval),
+                               nameof(BurstDuration),
+                               nameof(InterBurstInterval),
+                               nameof(PulseTrainDuration)
+                           });
+            }
         }
     }
 }

--- a/src/Bonsai.PulsePal/Configuration/OutputChannelConfiguration.cs
+++ b/src/Bonsai.PulsePal/Configuration/OutputChannelConfiguration.cs
@@ -1,0 +1,219 @@
+﻿using System.ComponentModel;
+
+namespace Bonsai.PulsePal
+{
+    /// <summary>
+    /// Represents pulse train configuration parameters for an output channel on a
+    /// Pulse Pal device.
+    /// </summary>
+    public class OutputChannelConfiguration : OutputChannelParameterConfiguration
+    {
+        const string VoltageCategory = "Pulse Voltage";
+        const string TimingCategory = "Pulse Timing";
+        const string CustomTrainCategory = "Custom Train";
+        const string TriggerCategory = "Pulse Trigger";
+
+        /// <summary>
+        /// Gets or sets a value specifying whether to use biphasic or
+        /// monophasic pulses.
+        /// </summary>
+        [Category(VoltageCategory)]
+        [Description("Specifies whether to use biphasic or monophasic pulses.")]
+        public bool Biphasic { get; set; }
+
+        /// <summary>
+        /// Gets or sets the voltage for the first phase of each pulse.
+        /// </summary>
+        [Category(VoltageCategory)]
+        [Range(MinVoltage, MaxVoltage)]
+        [Precision(VoltageDecimalPlaces, VoltageIncrement)]
+        [Editor(DesignTypes.SliderEditor, DesignTypes.UITypeEditor)]
+        [Description("The voltage for the first phase of each pulse.")]
+        public double Phase1Voltage { get; set; }
+
+        /// <summary>
+        /// Gets or sets the voltage for the second phase of each pulse.
+        /// </summary>
+        [Category(VoltageCategory)]
+        [Range(MinVoltage, MaxVoltage)]
+        [Precision(VoltageDecimalPlaces, VoltageIncrement)]
+        [Editor(DesignTypes.SliderEditor, DesignTypes.UITypeEditor)]
+        [Description("The voltage for the second phase of each pulse.")]
+        public double Phase2Voltage { get; set; }
+
+        /// <summary>
+        /// Gets or sets the resting voltage, in the range [-10, 10] volts.
+        /// </summary>
+        [Category(VoltageCategory)]
+        [Range(MinVoltage, MaxVoltage)]
+        [Precision(VoltageDecimalPlaces, VoltageIncrement)]
+        [Editor(DesignTypes.SliderEditor, DesignTypes.UITypeEditor)]
+        [Description("The resting voltage.")]
+        public double RestingVoltage { get; set; }
+
+        /// <summary>
+        /// Gets or sets the duration of the first phase of the pulse, in the range
+        /// [0.0001, 3600] seconds.
+        /// </summary>
+        [Category(TimingCategory)]
+        [Range(MinTimePeriod, MaxTimePeriod)]
+        [Precision(TimeDecimalPlaces, MinTimePeriod)]
+        [Editor(DesignTypes.SliderEditor, DesignTypes.UITypeEditor)]
+        [Description("The duration of the first phase of the pulse, in seconds.")]
+        public double Phase1Duration { get; set; } = MinTimePeriod;
+
+        /// <summary>
+        /// Gets or sets the interval between the first and second phase of a biphasic pulse,
+        /// in the range [0, 3600] seconds.
+        /// </summary>
+        [Category(TimingCategory)]
+        [Range(0, MaxTimePeriod)]
+        [Precision(TimeDecimalPlaces, MinTimePeriod)]
+        [Editor(DesignTypes.SliderEditor, DesignTypes.UITypeEditor)]
+        [Description("The interval between the first and second phase of a biphasic pulse, in seconds.")]
+        public double InterPhaseInterval { get; set; }
+
+        /// <summary>
+        /// Gets or sets the duration of the second phase of the pulse, in the range
+        /// [0.0001, 3600] seconds.
+        /// </summary>
+        [Category(TimingCategory)]
+        [Range(MinTimePeriod, MaxTimePeriod)]
+        [Precision(TimeDecimalPlaces, MinTimePeriod)]
+        [Editor(DesignTypes.SliderEditor, DesignTypes.UITypeEditor)]
+        [Description("The duration of the second phase of the pulse, in seconds.")]
+        public double Phase2Duration { get; set; } = MinTimePeriod;
+
+        /// <summary>
+        /// Gets or sets the interval between pulses, in the range [0.0001, 3600] seconds.
+        /// </summary>
+        [Category(TimingCategory)]
+        [Range(MinTimePeriod, MaxTimePeriod)]
+        [Precision(TimeDecimalPlaces, MinTimePeriod)]
+        [Editor(DesignTypes.SliderEditor, DesignTypes.UITypeEditor)]
+        [Description("The interval between pulses, in seconds.")]
+        public double InterPulseInterval { get; set; } = MinTimePeriod;
+
+        /// <summary>
+        /// Gets or sets the duration of a pulse burst, in the range
+        /// [0, 3600] seconds. If set to zero, bursts are disabled.
+        /// </summary>
+        [Category(TimingCategory)]
+        [Range(0, MaxTimePeriod)]
+        [Precision(TimeDecimalPlaces, MinTimePeriod)]
+        [Editor(DesignTypes.SliderEditor, DesignTypes.UITypeEditor)]
+        [Description("The duration of a pulse burst, in seconds. If set to zero, bursts are disabled.")]
+        public double BurstDuration { get; set; }
+
+        /// <summary>
+        /// Gets or sets the duration of the off-time between bursts, in the range
+        /// [0.0001, 3600] seconds.
+        /// </summary>
+        [Category(TimingCategory)]
+        [Range(MinTimePeriod, MaxTimePeriod)]
+        [Precision(TimeDecimalPlaces, MinTimePeriod)]
+        [Editor(DesignTypes.SliderEditor, DesignTypes.UITypeEditor)]
+        [Description("The duration of the off-time between bursts, in seconds.")]
+        public double InterBurstInterval { get; set; } = MinTimePeriod;
+
+        /// <summary>
+        /// Gets or sets the duration of the pulse train, in the range
+        /// [0.0001, 3600] seconds.
+        /// </summary>
+        [Category(TimingCategory)]
+        [Range(MinTimePeriod, MaxTimePeriod)]
+        [Precision(TimeDecimalPlaces, MinTimePeriod)]
+        [Editor(DesignTypes.SliderEditor, DesignTypes.UITypeEditor)]
+        [Description("The duration of the pulse train, in seconds.")]
+        public double PulseTrainDuration { get; set; } = MinTimePeriod;
+
+        /// <summary>
+        /// Gets or sets the delay to start the pulse train, in the range
+        /// [0.0001, 3600] seconds.
+        /// </summary>
+        [Category(TimingCategory)]
+        [Range(MinTimePeriod, MaxTimePeriod)]
+        [Precision(TimeDecimalPlaces, MinTimePeriod)]
+        [Editor(DesignTypes.SliderEditor, DesignTypes.UITypeEditor)]
+        [Description("The delay to start the pulse train, in seconds.")]
+        public double PulseTrainDelay { get; set; } = MinTimePeriod;
+
+        /// <summary>
+        /// Gets or sets a value specifying the identity of the custom pulse train
+        /// to use on this output channel.
+        /// </summary>
+        [Category(CustomTrainCategory)]
+        [Description("Specifies the identity of the custom pulse train to use on this output channel.")]
+        public CustomTrainId CustomTrainIdentity { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value specifying the interpretation of pulse times in the
+        /// custom pulse train.
+        /// </summary>
+        [Category(CustomTrainCategory)]
+        [Description("Specifies the interpretation of pulse times in the custom pulse train.")]
+        public CustomTrainTarget CustomTrainTarget { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value specifying whether the output channel
+        /// will loop its custom pulse train.
+        /// </summary>
+        [Category(CustomTrainCategory)]
+        [Description("Specifies whether the output channel will loop its custom pulse train.")]
+        public bool CustomTrainLoop { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value specifying whether trigger channel 1 can trigger
+        /// this output channel.
+        /// </summary>
+        [Category(TriggerCategory)]
+        [Description("Specifies whether trigger channel 1 can trigger this output channel.")]
+        public bool TriggerOnChannel1 { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value specifying whether trigger channel 2 can trigger
+        /// this output channel.
+        /// </summary>
+        [Category(TriggerCategory)]
+        [Description("Specifies whether trigger channel 2 can trigger this output channel.")]
+        public bool TriggerOnChannel2 { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value specifying whether to set the output channel in
+        /// continuous loop mode.
+        /// </summary>
+        [Category(TriggerCategory)]
+        [Description("Specifies whether to set the output channel in continuous loop mode.")]
+        public bool ContinuousLoop { get; set; }
+
+        /// <inheritdoc/>
+        public override void Configure(PulsePalDevice pulsePal)
+        {
+            var channel = Channel;
+            pulsePal.SetBiphasic(channel, Biphasic);
+            pulsePal.SetPhase1Voltage(channel, Phase1Voltage);
+            pulsePal.SetPhase2Voltage(channel, Phase2Voltage);
+            pulsePal.SetPhase1Duration(channel, Phase1Duration);
+            pulsePal.SetInterPhaseInterval(channel, InterPhaseInterval);
+            pulsePal.SetPhase2Duration(channel, Phase2Duration);
+            pulsePal.SetInterPulseInterval(channel, InterPulseInterval);
+            pulsePal.SetBurstDuration(channel, BurstDuration);
+            pulsePal.SetInterBurstInterval(channel, InterBurstInterval);
+            pulsePal.SetPulseTrainDuration(channel, PulseTrainDuration);
+            pulsePal.SetPulseTrainDelay(channel, PulseTrainDelay);
+            pulsePal.SetTriggerOnChannel1(channel, TriggerOnChannel1);
+            pulsePal.SetTriggerOnChannel2(channel, TriggerOnChannel2);
+            pulsePal.SetCustomTrainIdentity(channel, CustomTrainIdentity);
+            pulsePal.SetCustomTrainTarget(channel, CustomTrainTarget);
+            pulsePal.SetCustomTrainLoop(channel, CustomTrainLoop);
+            pulsePal.SetRestingVoltage(channel, RestingVoltage);
+            pulsePal.SetContinuousLoop(channel, ContinuousLoop);
+        }
+
+        /// <inheritdoc/>
+        public override string ToString()
+        {
+            return Channel == 0 ? nameof(OutputChannelConfiguration) : $"{Channel}";
+        }
+    }
+}

--- a/src/Bonsai.PulsePal/Configuration/OutputChannelConfigurationCollection.cs
+++ b/src/Bonsai.PulsePal/Configuration/OutputChannelConfigurationCollection.cs
@@ -5,14 +5,14 @@ namespace Bonsai.PulsePal
     /// <summary>
     /// Represents a collection of output channel configuration objects.
     /// </summary>
-    public class ConfigureOutputChannelCollection : KeyedCollection<OutputChannel, ConfigureOutputChannel>
+    public class OutputChannelConfigurationCollection : KeyedCollection<OutputChannel, OutputChannelConfiguration>
     {
         /// <summary>
         /// Returns the key for the specified configuration object.
         /// </summary>
         /// <param name="item">The configuration object from which to extract the key.</param>
         /// <returns>The key for the specified configuration object.</returns>
-        protected override OutputChannel GetKeyForItem(ConfigureOutputChannel item)
+        protected override OutputChannel GetKeyForItem(OutputChannelConfiguration item)
         {
             return item.Channel;
         }

--- a/src/Bonsai.PulsePal/Configuration/OutputChannelParameterConfiguration.cs
+++ b/src/Bonsai.PulsePal/Configuration/OutputChannelParameterConfiguration.cs
@@ -19,7 +19,8 @@ namespace Bonsai.PulsePal
         /// <summary>
         /// Gets or sets a value specifying the output channel to configure.
         /// </summary>
+        [Category(ChannelCategory)]
         [Description("Specifies the output channel to configure.")]
-        public OutputChannel Channel { get; set; } = OutputChannel.Channel1;
+        public OutputChannel Channel { get; set; }
     }
 }

--- a/src/Bonsai.PulsePal/Configuration/TriggerChannelConfiguration.cs
+++ b/src/Bonsai.PulsePal/Configuration/TriggerChannelConfiguration.cs
@@ -1,0 +1,30 @@
+﻿using System.ComponentModel;
+
+namespace Bonsai.PulsePal
+{
+    /// <summary>
+    /// Represents configuration parameters for a trigger channel on a Pulse Pal device.
+    /// </summary>
+    public class TriggerChannelConfiguration : TriggerChannelParameterConfiguration
+    {
+        /// <summary>
+        /// Gets or sets a value specifying the behavior of the trigger channel.
+        /// </summary>
+        [Category(ChannelCategory)]
+        [Description("Specifies the behavior of the trigger channel.")]
+        public TriggerMode TriggerMode { get; set; }
+
+        /// <inheritdoc/>
+        public override void Configure(PulsePalDevice pulsePal)
+        {
+            var channel = Channel;
+            pulsePal.SetTriggerMode(channel, TriggerMode);
+        }
+
+        /// <inheritdoc/>
+        public override string ToString()
+        {
+            return Channel == 0 ? nameof(TriggerChannelConfiguration) : $"{Channel}";
+        }
+    }
+}

--- a/src/Bonsai.PulsePal/Configuration/TriggerChannelConfigurationCollection.cs
+++ b/src/Bonsai.PulsePal/Configuration/TriggerChannelConfigurationCollection.cs
@@ -5,14 +5,14 @@ namespace Bonsai.PulsePal
     /// <summary>
     /// Represents a collection of trigger channel configuration objects.
     /// </summary>
-    public class ConfigureTriggerChannelCollection : KeyedCollection<TriggerChannel, ConfigureTriggerChannel>
+    public class TriggerChannelConfigurationCollection : KeyedCollection<TriggerChannel, TriggerChannelConfiguration>
     {
         /// <summary>
         /// Returns the key for the specified configuration object.
         /// </summary>
         /// <param name="item">The configuration object from which to extract the key.</param>
         /// <returns>The key for the specified configuration object.</returns>
-        protected override TriggerChannel GetKeyForItem(ConfigureTriggerChannel item)
+        protected override TriggerChannel GetKeyForItem(TriggerChannelConfiguration item)
         {
             return item.Channel;
         }

--- a/src/Bonsai.PulsePal/Configuration/TriggerChannelParameterConfiguration.cs
+++ b/src/Bonsai.PulsePal/Configuration/TriggerChannelParameterConfiguration.cs
@@ -9,9 +9,10 @@ namespace Bonsai.PulsePal
     public abstract class TriggerChannelParameterConfiguration : ChannelParameterConfiguration
     {
         /// <summary>
-        /// Gets or sets a value specifying the output channel to configure.
+        /// Gets or sets a value specifying the trigger channel to configure.
         /// </summary>
-        [Description("Specifies the output channel to configure.")]
-        public TriggerChannel Channel { get; set; } = TriggerChannel.Channel1;
+        [Category(ChannelCategory)]
+        [Description("Specifies the trigger channel to configure.")]
+        public TriggerChannel Channel { get; set; }
     }
 }

--- a/src/Bonsai.PulsePal/ConfigureOutputChannel.cs
+++ b/src/Bonsai.PulsePal/ConfigureOutputChannel.cs
@@ -8,22 +8,11 @@ namespace Bonsai.PulsePal
     /// Represents an operator that configures output channel parameters on a
     /// Pulse Pal device.
     /// </summary>
+    [Combinator]
+    [WorkflowElementCategory(ElementCategory.Sink)]
     [Description("Configures output channel parameters on a Pulse Pal device.")]
-    public class ConfigureOutputChannel : Sink, INamedElement
+    public class ConfigureOutputChannel : OutputChannelConfiguration, INamedElement
     {
-        const string ChannelCategory = "Channel";
-        const string VoltageCategory = "Pulse Voltage";
-        const string TimingCategory = "Pulse Timing";
-        const string CustomTrainCategory = "Custom Train";
-        const string TriggerCategory = "Pulse Trigger";
-        const double MinVoltage = PulsePalDevice.MinVoltage;
-        const double MaxVoltage = PulsePalDevice.MaxVoltage;
-        const double MinTimePeriod = PulsePalDevice.MinTimePeriod;
-        const double MaxTimePeriod = PulsePalDevice.MaxTimePeriod;
-        const int VoltageDecimalPlaces = OutputChannelParameterConfiguration.VoltageDecimalPlaces;
-        const double VoltageIncrement = OutputChannelParameterConfiguration.VoltageIncrement;
-        const int TimeDecimalPlaces = OutputChannelParameterConfiguration.TimeDecimalPlaces;
-
         string INamedElement.Name => Channel == 0
             ? nameof(ConfigureOutputChannel)
             : $"ConfigureOutput{Channel}";
@@ -35,186 +24,6 @@ namespace Bonsai.PulsePal
         [TypeConverter(typeof(DeviceNameConverter))]
         [Description("The name of the Pulse Pal device.")]
         public string DeviceName { get; set; } = nameof(PulsePal);
-
-        /// <summary>
-        /// Gets or sets the output channel to configure.
-        /// </summary>
-        [Category(ChannelCategory)]
-        [Description("The output channel to configure.")]
-        public OutputChannel Channel { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value specifying whether to use biphasic or
-        /// monophasic pulses.
-        /// </summary>
-        [Category(VoltageCategory)]
-        [Description("Specifies whether to use biphasic or monophasic pulses.")]
-        public bool Biphasic { get; set; }
-
-        /// <summary>
-        /// Gets or sets the voltage for the first phase of each pulse.
-        /// </summary>
-        [Category(VoltageCategory)]
-        [Range(MinVoltage, MaxVoltage)]
-        [Precision(VoltageDecimalPlaces, VoltageIncrement)]
-        [Editor(DesignTypes.SliderEditor, DesignTypes.UITypeEditor)]
-        [Description("The voltage for the first phase of each pulse.")]
-        public double Phase1Voltage { get; set; }
-
-        /// <summary>
-        /// Gets or sets the voltage for the second phase of each pulse.
-        /// </summary>
-        [Category(VoltageCategory)]
-        [Range(MinVoltage, MaxVoltage)]
-        [Precision(VoltageDecimalPlaces, VoltageIncrement)]
-        [Editor(DesignTypes.SliderEditor, DesignTypes.UITypeEditor)]
-        [Description("The voltage for the second phase of each pulse.")]
-        public double Phase2Voltage { get; set; }
-
-        /// <summary>
-        /// Gets or sets the resting voltage, in the range [-10, 10] volts.
-        /// </summary>
-        [Category(VoltageCategory)]
-        [Range(MinVoltage, MaxVoltage)]
-        [Precision(VoltageDecimalPlaces, VoltageIncrement)]
-        [Editor(DesignTypes.SliderEditor, DesignTypes.UITypeEditor)]
-        [Description("The resting voltage.")]
-        public double RestingVoltage { get; set; }
-
-        /// <summary>
-        /// Gets or sets the duration of the first phase of the pulse, in the range
-        /// [0.0001, 3600] seconds.
-        /// </summary>
-        [Category(TimingCategory)]
-        [Range(MinTimePeriod, MaxTimePeriod)]
-        [Precision(TimeDecimalPlaces, MinTimePeriod)]
-        [Editor(DesignTypes.SliderEditor, DesignTypes.UITypeEditor)]
-        [Description("The duration of the first phase of the pulse, in seconds.")]
-        public double Phase1Duration { get; set; } = MinTimePeriod;
-
-        /// <summary>
-        /// Gets or sets the interval between the first and second phase of a biphasic pulse,
-        /// in the range [0, 3600] seconds.
-        /// </summary>
-        [Category(TimingCategory)]
-        [Range(0, MaxTimePeriod)]
-        [Precision(TimeDecimalPlaces, MinTimePeriod)]
-        [Editor(DesignTypes.SliderEditor, DesignTypes.UITypeEditor)]
-        [Description("The interval between the first and second phase of a biphasic pulse, in seconds.")]
-        public double InterPhaseInterval { get; set; }
-
-        /// <summary>
-        /// Gets or sets the duration of the second phase of the pulse, in the range
-        /// [0.0001, 3600] seconds.
-        /// </summary>
-        [Category(TimingCategory)]
-        [Range(MinTimePeriod, MaxTimePeriod)]
-        [Precision(TimeDecimalPlaces, MinTimePeriod)]
-        [Editor(DesignTypes.SliderEditor, DesignTypes.UITypeEditor)]
-        [Description("The duration of the second phase of the pulse, in seconds.")]
-        public double Phase2Duration { get; set; } = MinTimePeriod;
-
-        /// <summary>
-        /// Gets or sets the interval between pulses, in the range [0.0001, 3600] seconds.
-        /// </summary>
-        [Category(TimingCategory)]
-        [Range(MinTimePeriod, MaxTimePeriod)]
-        [Precision(TimeDecimalPlaces, MinTimePeriod)]
-        [Editor(DesignTypes.SliderEditor, DesignTypes.UITypeEditor)]
-        [Description("The interval between pulses, in seconds.")]
-        public double InterPulseInterval { get; set; } = MinTimePeriod;
-
-        /// <summary>
-        /// Gets or sets the duration of a pulse burst, in the range
-        /// [0, 3600] seconds. If set to zero, bursts are disabled.
-        /// </summary>
-        [Category(TimingCategory)]
-        [Range(0, MaxTimePeriod)]
-        [Precision(TimeDecimalPlaces, MinTimePeriod)]
-        [Editor(DesignTypes.SliderEditor, DesignTypes.UITypeEditor)]
-        [Description("The duration of a pulse burst, in seconds. If set to zero, bursts are disabled.")]
-        public double BurstDuration { get; set; }
-
-        /// <summary>
-        /// Gets or sets the duration of the off-time between bursts, in the range
-        /// [0.0001, 3600] seconds.
-        /// </summary>
-        [Category(TimingCategory)]
-        [Range(MinTimePeriod, MaxTimePeriod)]
-        [Precision(TimeDecimalPlaces, MinTimePeriod)]
-        [Editor(DesignTypes.SliderEditor, DesignTypes.UITypeEditor)]
-        [Description("The duration of the off-time between bursts, in seconds.")]
-        public double InterBurstInterval { get; set; } = MinTimePeriod;
-
-        /// <summary>
-        /// Gets or sets the duration of the pulse train, in the range
-        /// [0.0001, 3600] seconds.
-        /// </summary>
-        [Category(TimingCategory)]
-        [Range(MinTimePeriod, MaxTimePeriod)]
-        [Precision(TimeDecimalPlaces, MinTimePeriod)]
-        [Editor(DesignTypes.SliderEditor, DesignTypes.UITypeEditor)]
-        [Description("The duration of the pulse train, in seconds.")]
-        public double PulseTrainDuration { get; set; } = MinTimePeriod;
-
-        /// <summary>
-        /// Gets or sets the delay to start the pulse train, in the range
-        /// [0.0001, 3600] seconds.
-        /// </summary>
-        [Category(TimingCategory)]
-        [Range(MinTimePeriod, MaxTimePeriod)]
-        [Precision(TimeDecimalPlaces, MinTimePeriod)]
-        [Editor(DesignTypes.SliderEditor, DesignTypes.UITypeEditor)]
-        [Description("The delay to start the pulse train, in seconds.")]
-        public double PulseTrainDelay { get; set; } = MinTimePeriod;
-
-        /// <summary>
-        /// Gets or sets a value specifying the identity of the custom pulse train
-        /// to use on this output channel.
-        /// </summary>
-        [Category(CustomTrainCategory)]
-        [Description("Specifies the identity of the custom pulse train to use on this output channel.")]
-        public CustomTrainId CustomTrainIdentity { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value specifying the interpretation of pulse times in the
-        /// custom pulse train.
-        /// </summary>
-        [Category(CustomTrainCategory)]
-        [Description("Specifies the interpretation of pulse times in the custom pulse train.")]
-        public CustomTrainTarget CustomTrainTarget { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value specifying whether the output channel
-        /// will loop its custom pulse train.
-        /// </summary>
-        [Category(CustomTrainCategory)]
-        [Description("Specifies whether the output channel will loop its custom pulse train.")]
-        public bool CustomTrainLoop { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value specifying whether trigger channel 1 can trigger
-        /// this output channel.
-        /// </summary>
-        [Category(TriggerCategory)]
-        [Description("Specifies whether trigger channel 1 can trigger this output channel.")]
-        public bool TriggerOnChannel1 { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value specifying whether trigger channel 2 can trigger
-        /// this output channel.
-        /// </summary>
-        [Category(TriggerCategory)]
-        [Description("Specifies whether trigger channel 2 can trigger this output channel.")]
-        public bool TriggerOnChannel2 { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value specifying whether to set the output channel in
-        /// continuous loop mode.
-        /// </summary>
-        [Category(TriggerCategory)]
-        [Description("Specifies whether to set the output channel in continuous loop mode.")]
-        public bool ContinuousLoop { get; set; }
 
         /// <summary>
         /// Configures the output channel parameters on the Pulse Pal device whenever
@@ -233,7 +42,7 @@ namespace Bonsai.PulsePal
         /// output channel parameters on the Pulse Pal device whenever the sequence
         /// emits a notification.
         /// </returns>
-        public override IObservable<TSource> Process<TSource>(IObservable<TSource> source)
+        public IObservable<TSource> Process<TSource>(IObservable<TSource> source)
         {
             return Observable.Using(
                 () => PulsePalManager.ReserveConnection(DeviceName),
@@ -261,35 +70,6 @@ namespace Bonsai.PulsePal
         public IObservable<PulsePalDevice> Process(IObservable<PulsePalDevice> source)
         {
             return source.Do(Configure);
-        }
-
-        internal void Configure(PulsePalDevice pulsePal)
-        {
-            var channel = Channel;
-            pulsePal.SetBiphasic(channel, Biphasic);
-            pulsePal.SetPhase1Voltage(channel, Phase1Voltage);
-            pulsePal.SetPhase2Voltage(channel, Phase2Voltage);
-            pulsePal.SetPhase1Duration(channel, Phase1Duration);
-            pulsePal.SetInterPhaseInterval(channel, InterPhaseInterval);
-            pulsePal.SetPhase2Duration(channel, Phase2Duration);
-            pulsePal.SetInterPulseInterval(channel, InterPulseInterval);
-            pulsePal.SetBurstDuration(channel, BurstDuration);
-            pulsePal.SetInterBurstInterval(channel, InterBurstInterval);
-            pulsePal.SetPulseTrainDuration(channel, PulseTrainDuration);
-            pulsePal.SetPulseTrainDelay(channel, PulseTrainDelay);
-            pulsePal.SetTriggerOnChannel1(channel, TriggerOnChannel1);
-            pulsePal.SetTriggerOnChannel2(channel, TriggerOnChannel2);
-            pulsePal.SetCustomTrainIdentity(channel, CustomTrainIdentity);
-            pulsePal.SetCustomTrainTarget(channel, CustomTrainTarget);
-            pulsePal.SetCustomTrainLoop(channel, CustomTrainLoop);
-            pulsePal.SetRestingVoltage(channel, RestingVoltage);
-            pulsePal.SetContinuousLoop(channel, ContinuousLoop);
-        }
-
-        /// <inheritdoc/>
-        public override string ToString()
-        {
-            return Channel == 0 ? nameof(ConfigureOutputChannel) : $"{Channel}";
         }
     }
 }

--- a/src/Bonsai.PulsePal/ConfigureTriggerChannel.cs
+++ b/src/Bonsai.PulsePal/ConfigureTriggerChannel.cs
@@ -7,11 +7,11 @@ namespace Bonsai.PulsePal
     /// <summary>
     /// Represents an operator that configures trigger channel parameters on a Pulse Pal device.
     /// </summary>
+    [Combinator]
+    [WorkflowElementCategory(ElementCategory.Sink)]
     [Description("Configures trigger channel parameters on a Pulse Pal device.")]
-    public class ConfigureTriggerChannel : Sink, INamedElement
+    public class ConfigureTriggerChannel : TriggerChannelConfiguration, INamedElement
     {
-        const string ChannelCategory = "Channel";
-
         string INamedElement.Name => Channel == 0
             ? nameof(ConfigureTriggerChannel)
             : $"ConfigureTrigger{Channel}";
@@ -23,20 +23,6 @@ namespace Bonsai.PulsePal
         [TypeConverter(typeof(DeviceNameConverter))]
         [Description("The name of the Pulse Pal device.")]
         public string DeviceName { get; set; } = nameof(PulsePal);
-
-        /// <summary>
-        /// Gets or sets the output channel to configure.
-        /// </summary>
-        [Category(ChannelCategory)]
-        [Description("The trigger channel to configure.")]
-        public TriggerChannel Channel { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value specifying the behavior of the trigger channel.
-        /// </summary>
-        [Category(ChannelCategory)]
-        [Description("Specifies the behavior of the trigger channel.")]
-        public TriggerMode TriggerMode { get; set; }
 
         /// <summary>
         /// Configures the trigger channel parameters on the Pulse Pal device whenever
@@ -55,7 +41,7 @@ namespace Bonsai.PulsePal
         /// trigger channel parameters on the Pulse Pal device whenever the sequence
         /// emits a notification.
         /// </returns>
-        public override IObservable<TSource> Process<TSource>(IObservable<TSource> source)
+        public IObservable<TSource> Process<TSource>(IObservable<TSource> source)
         {
             return Observable.Using(
                 () => PulsePalManager.ReserveConnection(DeviceName),
@@ -83,18 +69,6 @@ namespace Bonsai.PulsePal
         public IObservable<PulsePalDevice> Process(IObservable<PulsePalDevice> source)
         {
             return source.Do(Configure);
-        }
-
-        internal void Configure(PulsePalDevice pulsePal)
-        {
-            var channel = Channel;
-            pulsePal.SetTriggerMode(channel, TriggerMode);
-        }
-
-        /// <inheritdoc/>
-        public override string ToString()
-        {
-            return Channel == 0 ? nameof(ConfigureTriggerChannel) : $"{Channel}";
         }
     }
 }

--- a/src/Bonsai.PulsePal/CreatePulsePal.cs
+++ b/src/Bonsai.PulsePal/CreatePulsePal.cs
@@ -14,8 +14,6 @@ namespace Bonsai.PulsePal
     [Description("Creates and configures a serial connection to a Pulse Pal device.")]
     public class CreatePulsePal : Source<PulsePalDevice>
     {
-        const string ChannelCategory = "Channel";
-
         readonly PulsePalConfiguration configuration = new();
 
         /// <summary>
@@ -39,16 +37,16 @@ namespace Bonsai.PulsePal
         /// <summary>
         /// Gets the collection of output channels to configure on the Pulse Pal device.
         /// </summary>
-        [Category(ChannelCategory)]
+        [Category(ChannelParameterConfiguration.ChannelCategory)]
         [Description("The collection of output channels to configure on the Pulse Pal device.")]
-        public ConfigureOutputChannelCollection OutputChannels => configuration.OutputChannels;
+        public OutputChannelConfigurationCollection OutputChannels => configuration.OutputChannels;
 
         /// <summary>
         /// Gets the collection of trigger channels to configure on the Pulse Pal device.
         /// </summary>
-        [Category(ChannelCategory)]
+        [Category(ChannelParameterConfiguration.ChannelCategory)]
         [Description("The collection of trigger channels to configure on the Pulse Pal device.")]
-        public ConfigureTriggerChannelCollection TriggerChannels => configuration.TriggerChannels;
+        public TriggerChannelConfigurationCollection TriggerChannels => configuration.TriggerChannels;
 
         /// <summary>
         /// Generates an observable sequence that contains the serial interface object.

--- a/src/Bonsai.PulsePal/PulsePalConfiguration.cs
+++ b/src/Bonsai.PulsePal/PulsePalConfiguration.cs
@@ -6,20 +6,20 @@
 
         public string PortName { get; set; }
 
-        public ConfigureOutputChannelCollection OutputChannels { get; } = new();
+        public OutputChannelConfigurationCollection OutputChannels { get; } = new();
 
-        public ConfigureTriggerChannelCollection TriggerChannels { get; } = new();
+        public TriggerChannelConfigurationCollection TriggerChannels { get; } = new();
 
         public void Configure(PulsePalDevice pulsePal)
         {
-            foreach (var outputChannel in OutputChannels)
+            foreach (var channelConfiguration in OutputChannels)
             {
-                outputChannel.Configure(pulsePal);
+                channelConfiguration.Configure(pulsePal);
             }
 
-            foreach (var triggerChannel in TriggerChannels)
+            foreach (var channelConfiguration in TriggerChannels)
             {
-                triggerChannel.Configure(pulsePal);
+                channelConfiguration.Configure(pulsePal);
             }
         }
     }


### PR DESCRIPTION
This PR refactors configuration classes to avoid redundant property definitions, and allow removing the unused `DeviceName` property from channel pulse train configurations included directly into the `CreatePulsePal` operator.

Finally, it reorders the pulse timing properties to follow the natural progression of the pulse train, to make it easier to map onto the documentation figure.

Fixes #45 