### PR TITLE
Fix actions version specificity and update to modern pages deployment

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,25 +1,25 @@
 name: Build
- 
+
 on:
   push:
     branches: [ main ]
   pull_request:
     branches: [ main ]
- 
+
 jobs:
   build:
     name: Build Solution
     runs-on: windows-latest
- 
+
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v4
 
       - name: Setup MSBuild
         uses: microsoft/setup-msbuild@v2
-        
+
       - name: Restore NuGet Packages
         run: msbuild -t:restore src/Bonsai.PulsePal.sln
-  
+
       - name: Build Solution
         run: msbuild src/Bonsai.PulsePal.sln /p:Configuration=Release

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,29 +1,38 @@
-# Builds and publishes the documentation website to gh-pages branch
+# Builds and publishes the documentation website
 name: Build docs
 
 on:
   workflow_dispatch:
+
+concurrency:
+  group: docs
+  cancel-in-progress: true
+
+permissions:
+  # Both required by actions/deploy-pages
+  pages: write
+  id-token: write
 
 jobs:
   build:
     runs-on: windows-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v4
         with:
           submodules: true
 
       - name: Setup MSBuild
         uses: microsoft/setup-msbuild@v2
-        
+
       - name: Restore NuGet Packages
         run: msbuild -t:restore src/Bonsai.PulsePal.sln
-  
+
       - name: Build Solution
         run: msbuild src/Bonsai.PulsePal.sln /p:Configuration=Release
-    
+
       - name: Setup .NET Core SDK
-        uses: actions/setup-dotnet@v4.0.0
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 7.x
 
@@ -37,15 +46,11 @@ jobs:
       - name: Build Documentation
         working-directory: docs
         run: .\build.ps1
-          
-      - name: Checkout gh-pages
-        uses: actions/checkout@v4.1.1
+
+      - name: Upload GitHub Pages Artifact
+        uses: actions/upload-pages-artifact@v3
         with:
-          ref: gh-pages
-          path: gh-pages
-      - name: Publish to github pages
-        uses: peaceiris/actions-gh-pages@v3.9.3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: docs/_site
-          force_orphan: true
+          path: docs/_site
+
+      - name: Deploy to GitHub Pages
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
**Before merging this PR:** Go to [the GitHub Pages settings](../settings/pages) for this repo and change the build/deployment source to "GitHub Actions".

------------

This PR removes unnecessary version specificity for actions used in GitHub Actions workflows in this repository. This reflects best practices and avoids upcoming issues with `actions/setup-dotnet`, see [this issue](https://github.com/bonsai-rx/bonsai/issues/2091) for details.

While I was at it I migrated the docs workflow to use the modern method for GitHub Pages deployment, and updated other actions as appropriate.